### PR TITLE
Migrate oem-qa-checkbox-installer

### DIFF
--- a/Tools/PC/oem-qa-checkbox-installer/README.md
+++ b/Tools/PC/oem-qa-checkbox-installer/README.md
@@ -1,7 +1,7 @@
-# install_checkbox-provider
+# Install OEM Checkbox providers
 
 ## Introduce
-This is a tool to help you set up the test environment, like installing the main package `checkbox-cli`, and also other essential packages.
+This is a tool to help you set up the test environment, like installing the main package `checkbox-ng`, and also other essential packages.
 
 ## Usage
 1. Copy this folder to your computer.

--- a/Tools/PC/oem-qa-checkbox-installer/README.md
+++ b/Tools/PC/oem-qa-checkbox-installer/README.md
@@ -1,0 +1,19 @@
+# install_checkbox-provider
+
+## Introduce
+This is a tool to help you set up the test environment, like installing the main package `checkbox-cli`, and also other essential packages.
+
+## Usage
+1. Copy this folder to your computer.
+2. Change directory to this folder.
+3. Modify your information inside the `./conf/setting.conf`.
+   1. `username`: Launchpad ID
+   2. `ppa_password`: 
+      1. go to [launchpad](https://launchpad.net/people/+me/+archivesubscriptions/10011) and find the string between `https://%{yourname}:` and `@private-ppa…` is your ppa_password.
+   3. `api_key`:
+      1. Get your api key from [here](https://certification.canonical.com/me).
+   4. `provider`: `stella`, `somerville` or `sutton`.
+   5. `repository`: `stable`, `testing` or `daily`.
+4. Run command `$ sh oem-qa-checkbox-installer.sh`.
+5. Follow the instructions of the script.
+6. Test environment setup done! Now you can run `stella-cli`, `somerville-cli` or `sutton-cli`. to test your DUT.

--- a/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
@@ -71,7 +71,7 @@ def main():
     boxercfg = config["boxer"]
     username = boxercfg["username"]
     ppa_password = boxercfg["ppa_password"]
-    provider = args.provider or boxercfg["provider"] or "sutton"
+    provider = args.provider or boxercfg["provider"]
     repository = args.repository or boxercfg["repository"] or "stable"
 
     pre_install()

--- a/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+
+import argparse
+import configparser
+import os
+import subprocess
+import time
+
+VERSION="2.2"
+PROVIDERS = ("somerville",
+             "sutton",
+             "stella",
+             "kittyhawk",
+             "otaru",
+             "wenshan",
+             )
+CHECKBOX_REPOS = {"stable": "ppa:hardware-certification/public",
+                  "testing": "ppa:checkbox-dev/testing",
+                  "daily": "ppa:checkbox-dev/ppa"}
+FWTS_REPO = "ppa:firmware-testing-team/ppa-fwts-stable"
+PC_ENABLE_REPO = "ppa:oem-solutions-engineers/pc-enablement-tools"
+OEM_REPO = "https://{username}:{password}@private-ppa.launchpad.net/oem-services-qa/ppa/ubuntu"
+OEM_SOURCE_LIST = "deb https://private-ppa.launchpad.net/oem-services-qa/ppa/ubuntu {codename} main"
+
+# Public key for OEM Services PPA (PUBKEY 17B878BE09D5DC1F)
+OEM_PPA_GPG = """
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Hostname: 
+Version: Hockeypuck ~unreleased
+
+xo0ESkJgvQEEANvHkVH7riYJ1+mIjtCg15XI/QpVKDAuDVF8B6unTVottuEQ1WZw
+6ESWE8q+k004iroTof8XB8zYGDcqUIKZ5rfsPtgQklq2QltQdhRm4bnpr8SlCBJZ
+l83PcUmOZ77bihdxyzHqTR3qRl3Yz+aRVunG9decBWN+D24JrJQgP1nPABEBAAHN
+IUxhdW5jaHBhZCBQUEEgZm9yIE9FTSBTZXJ2aWNlcyBRQcK2BBMBAgAgBQJKQmC9
+AhsDBgsJCAcDAgQVAggDBBYCAwECHgECF4AACgkQF7h4vgnV3B+jdAQAg+Wkf4pF
+q1UIe1r6KVYHDGjaS2J6oLPN781/ccMqEthFUfns5s+nqbvNZfvSjZbTt9wc2EQz
+5vJDV7uyj1MQWJDaWgTHTRxAOMiaSNKPQ50qjhGcprhjZnHxJa71PTRB+8pqiTBw
+OqboGUSfWwcOY7fN98NQj1aJGCiDr2Jy9tE=
+=ER36
+-----END PGP PUBLIC KEY BLOCK-----
+"""
+
+
+# Colors for messages output
+class tcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def main():
+    print("== Boxer v{} ==".format(VERSION))
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", help="Command to run (default: install)",
+                        nargs="?", default="install")
+    parser.add_argument("-p", "--provider",
+                        help="Provider name ({})".format(", ".join(PROVIDERS)))
+    parser.add_argument("-r", "--repository",
+                        help="Checkbox repository to use ({})"
+                             .format(", ".join(CHECKBOX_REPOS)))
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser()
+    while not config.read("./conf/setting.conf"):
+        create_config()
+    boxercfg = config["boxer"]
+    username = boxercfg["username"]
+    ppa_password = boxercfg["ppa_password"]
+    provider = args.provider or boxercfg["provider"] or "sutton"
+    repository = args.repository or boxercfg["repository"] or "stable"
+
+    pre_install()
+    # We remove any existing PPA before adding the new ones
+    setup_public_ppa(repository, username, ppa_password, remove=True)
+    setup_public_ppa(repository, username, ppa_password)
+    setup_oem_ppa(username, ppa_password)
+    install(provider)
+
+
+def create_config():
+    """ If boxer config file not found, this will ask the user a few questions
+    and create one next to the boxer script."""
+
+    print("Hi! It looks like there is no boxer.conf file yet. Let's create one!")
+    username = input("What's your Launchpad username? ")
+    print()
+    print("Let's find the password you need to access the OEM providers repository.")
+    # The link to personal private ppa subscription management page of <https://launchpad.net/~oem-services-qa/+archive/ubuntu/ppa>
+    print("Go to <https://launchpad.net/~{}/+archivesubscriptions/10011>".format(username))
+    print("You should see something like")
+    print()
+    print("\tdeb https://{}:<password>@private-ppa...".format(username))
+    print()
+    ppa_password = input("Copy the password and paste it here: ")
+    print()
+    print("Boxer currently supports the following providers: ", end="")
+    print(", ".join(PROVIDERS))
+    provider = input("What provider do you want to use by default? ")
+    print()
+    print("Checkbox can be installed from the following repositories: ", end="")
+    print(", ".join(CHECKBOX_REPOS))
+    repository = input("Which repository do you want to use by default? ")
+
+    config = configparser.ConfigParser()
+    config.add_section("boxer")
+    boxercfg = config["boxer"]
+    boxercfg["username"] = username
+    boxercfg["ppa_password"] = ppa_password
+    boxercfg["provider"] = provider
+    boxercfg["repository"] = repository
+
+    with open('./conf/setting.conf', 'w') as configfile:
+        config.write(configfile)
+    print()
+    print("All set!")
+    print("Next time you run boxer, make sure your boxer.conf is located in the same directory!")
+    print()
+    time.sleep(3)
+
+def setup_public_ppa(repo, username, password, remove=False):
+    """
+    Setup required public PPAs to install Checkbox OEM stack.
+    By default, it adds the PPAs. If `remove` is set, the PPAs are removed.
+    """
+    print("Setting up the public PPAs...")
+    # If we remove the PPAs, we want to make sure we remove any Checkbox PPA,
+    # not only the PPA we are trying to install, otherwise if the previously
+    # chosen PPA was 'daily', and we want to install 'stable', in the end we'll
+    # still have the version from daily installed...
+    if remove:
+        checkbox_repo = list(CHECKBOX_REPOS.values())
+    else:
+        checkbox_repo = [CHECKBOX_REPOS[repo]]
+    repos = checkbox_repo + [FWTS_REPO, PC_ENABLE_REPO]
+    for ppa in repos:
+        if remove:
+            print("Removing PPA {}...".format(ppa))
+            command = f"sudo add-apt-repository -y -r {ppa}"
+        else:
+            print("Adding PPA {}...".format(ppa))
+            command = f"sudo add-apt-repository -y {ppa}"
+        run_command(command)
+
+def add_oem_source_list():
+    """
+    Add OEM Services PPA to sources.list.d and update the apt database
+    """
+    print("Adding the OEM Providers PPA...")
+    cmd = "lsb_release -sc"
+    output = subprocess.run(cmd.split(), capture_output=True)
+    ubuntu_codename = output.stdout.decode().strip()
+    source_list = OEM_SOURCE_LIST.format(codename=ubuntu_codename)
+    cmd = f"sudo sh -c 'echo \"{source_list}\" > /etc/apt/sources.list.d/oem-services-qa-ubuntu-ppa.list'"
+    run_command(cmd, shell=True)
+    cmd = "sudo apt update"
+    run_command(cmd)
+
+def add_auth_conf(username, password):
+    """
+    Add authentication data for the OEM Services PPA to auth.conf.d
+    """
+    print("Add authentication data for the OEM Services PPA to auth.conf.d...")
+    auth_conf = f"machine private-ppa.launchpad.net/oem-services-qa/ppa/ubuntu login {username} password {password}"
+    cmd = f"sudo sh -c 'echo \"{auth_conf}\" > /etc/apt/auth.conf.d/oem-services-qa-ubuntu-ppa.conf'"
+    run_command(cmd, shell=True)
+
+def add_oem_ppa_gpg():
+    """
+    Add OEM Services PPA public GPG key to the trusted.gpg.d directory
+    For more info, see:
+    <https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html>
+    """
+    print("Add OEM Services PPA public GPG key to the trusted.gpg.d directory...")
+    cmd = f"sudo sh -c 'echo \"{OEM_PPA_GPG}\" | gpg --dearmor > /etc/apt/trusted.gpg.d/oem-services-qa-ubuntu-ppa.gpg'"
+    run_command(cmd, shell=True)
+
+def setup_oem_ppa(username, password):
+    """
+    Setup the OEM providers PPA.
+    """
+    add_auth_conf(username, password)
+    add_oem_ppa_gpg()
+    add_oem_source_list()
+
+def run_command(command, shell=False, check=True):
+    if not shell:
+        command = command.split()
+    try:
+        subprocess.run(command, shell=shell, check=check)
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(f"{tcolors.FAIL}Error:{tcolors.ENDC} {e}")
+
+def pre_install():
+    # Add sudoer setting file to allow Checkbox to run sudo commands without
+    # having to enter the sudo password.
+    user = os.getenv("USER")
+    cmd = f"echo '{user} ALL=(ALL:ALL) NOPASSWD: ALL' | sudo tee /etc/sudoers.d/checkbox"
+    run_command(cmd, shell=True)
+
+    # Add GPG keys from the different repositories.
+    commands = ("sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 2BBDF2BD 09D5DC1F 6BE75981",)
+    print("Running pre-install commands...")
+    for cmd in commands:
+        run_command(cmd)
+
+def install(provider):
+    print("Purging Checkbox-related packages that might already be installed...")
+    cmd = "sudo apt-get purge -y .*plainbox.* .*checkbox.*"
+    run_command(cmd)
+
+    print("Installing Checkbox base packages...")
+    cmd = ("sudo DEBIAN_FRONTEND=noninteractive apt install -y "
+           "--allow-downgrades --allow-remove-essential "
+           "--allow-change-held-packages "
+           "checkbox-ng "
+           "checkbox-provider-resource "
+           "checkbox-provider-certification-client "
+           "checkbox-provider-base "
+           "canonical-certification-client")
+    run_command(cmd)
+
+    print("Installing provider {}...".format(provider))
+    # Add DEBIAN_FRONTEND=noninteractive to avoid interruption, example: postfix
+    cmd = ("sudo DEBIAN_FRONTEND=noninteractive apt install -y "
+           "--allow-downgrades --allow-remove-essential "
+           "--allow-change-held-packages plainbox-provider-oem-"+provider)
+    run_command(cmd)
+
+if __name__ == "__main__":
+    main()

--- a/Tools/PC/oem-qa-checkbox-installer/bin/env-setup.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/env-setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo -e "\nSetting up the testing environment..."
+
+pwd='u'
+
+# Disable auto upgrade
+echo ${pwd} | sudo -S mv /etc/apt/apt.conf.d/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades.orig
+echo -e "\033[1;32mModify 20auto-upgrades file: \033[0m"
+cat << "EOF" | sudo tee /etc/apt/apt.conf.d/20auto-upgrades
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
+echo -e "\033[1;42;37mdone\033[0m"
+
+# Disable auto suspend when plugged in
+echo -e "\033[1;32mDisable auto suspend when plugged in\033[0m"
+# Settings > Power > Power > Automatic Suspend > Plugged in > Off
+gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type nothing && echo -e "\033[1;42;37mdone\033[0m"
+
+# Disable auto suspend when on battery power
+echo -e "\033[1;32mDisable auto suspend when on battery\033[0m"
+# Settings > Power > Power > Automatic Suspend > On Battery Power > Off
+gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type nothing && echo -e "\033[1;42;37mdone\033[0m"
+
+# Disable auto blank screen
+echo -e "\033[1;32mDisable auto blank screen\033[0m"
+# Settings > Privacy > Screen > Blank Screen Delay > Never
+gsettings set org.gnome.desktop.session idle-delay 0 && echo -e "\033[1;42;37mdone\033[0m"

--- a/Tools/PC/oem-qa-checkbox-installer/bin/get-hw-info.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/get-hw-info.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo -e "\nGetting hardware info..."
+
+myCPU=$(sudo dmidecode -s processor-version)
+myGPU=$(lspci -nnv | grep "VGA controller\|NVIDIA\|Display controller" | cut -c 9- | sed '2,4s/^/		/')
+myWireless=$(lspci -nnv | grep 'Network controller' | cut -c 36-)
+myWiFiSub=$(lspci -nnv | grep -A 2 'Network controller' | grep -i subsystem | cut -c 13-)
+myManifest=$(ubuntu-report show | grep DCD | awk '{print $2}' | sed 's/"//g')
+myKernel=$(uname -a)
+myBIOSvers=$(sudo dmidecode -s bios-version)
+
+{
+    echo -e "CPU:\t\t${myCPU} "
+    echo -e "GPU:\t\t${myGPU} "
+    echo -e "Wireless:\t\t${myWireless} "
+    echo -e "WiFi Sub ID:\t${myWiFiSub} "
+    echo -e "Manifest Info:\t${myManifest}"
+    echo -e "Kernel Version:\t${myKernel}"
+    echo -e "BIOS:\t\t${myBIOSvers} "
+}   >> "./hardware_info.txt"

--- a/Tools/PC/oem-qa-checkbox-installer/bin/get-id-info.py
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/get-id-info.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import requests
+import json
+import configparser
+
+print("\nGetting ID info from C3...")
+
+config = configparser.ConfigParser()
+config.read("./conf/setting.conf")
+c3cfg = config["c3"]
+username = c3cfg["username"]
+api_key = c3cfg["api_key"]
+cid = input("Please enter CID: ")
+
+url = f"https://certification.canonical.com/api/v1/hardware/{cid}/?username={username}&api_key={api_key}&format=json"
+data = requests.get(url)
+data_req = json.loads(data.text)
+
+with open("hardware_info.txt", "wt") as f:
+    f.write(f"CID:\t\t{cid}\n")
+    f.write(f"Secure ID:\t{data_req.get('secure_id')}\n")
+    f.write(f"C3:\t\thttps://certification.canonical.com/hardware/{cid}\n")
+    f.write(f"SKU:\t\t{data_req.get('sku')}\n")

--- a/Tools/PC/oem-qa-checkbox-installer/bin/install-packages.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/install-packages.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo -e "\nInstalling other essential packages..."
+
+pwd='u'
+
+# Install bugit
+echo "Installing bugit..."
+echo ${pwd} | sudo -S snap install bugit --edge --devmode
+
+# Install sosreport
+echo "Installing sosreport..."
+echo ${pwd} | sudo -S snap install sosreport --classic
+
+# Install openssh
+echo "Installing openssh-server..."
+echo ${pwd} | sudo apt install -y openssh-server
+echo "Enabling ssh.service..."
+echo ${pwd} | sudo systemctl enable ssh --now

--- a/Tools/PC/oem-qa-checkbox-installer/conf/plainbox.conf
+++ b/Tools/PC/oem-qa-checkbox-installer/conf/plainbox.conf
@@ -1,0 +1,23 @@
+[environment]
+ROUTERS = multiple
+WPA_BG_SSID = cert-bg-wpa-tel-l3-01
+WPA_BG_PSK = insecure
+WPA_N_SSID = cert-n-wpa-tel-l3-01
+WPA_N_PSK = insecure
+WPA_AC_SSID = cert-ac-wpa-tel-l3-01
+WPA_AC_PSK = insecure
+WPA_AX_SSID = cert-ax-wpa-tel-l3-01
+WPA_AX_PSK = insecure
+WPA3_AX_SSID = cert-ax-wpa3-tel-l3-01
+WPA3_AX_PSK = insecure
+OPEN_BG_SSID = cert-bg-open-tel-l3-01
+OPEN_N_SSID = cert-n-open-tel-l3-01
+OPEN_AC_SSID = cert-ac-open-tel-l3-01
+OPEN_AX_SSID = cert-ax-open-tel-l3-01
+# === Select one BTDEVADDR below ===
+BTDEVADDR = 7C:B2:7D:4B:14:95
+# BTDEVADDR = 28:3A:4D:46:79:C0
+# BTDEVADDR = 34:6F:24:A8:93:EE
+# ==================================
+TRANSFER_SERVER = cdimage.ubuntu.com
+TEST_TARGET_IPERF = 10.102.182.100,10.102.182.137,10.102.182.101,10.102.182.48

--- a/Tools/PC/oem-qa-checkbox-installer/conf/setting.conf
+++ b/Tools/PC/oem-qa-checkbox-installer/conf/setting.conf
@@ -1,0 +1,9 @@
+[boxer]
+username = yourname
+ppa_password = yourppapwd
+provider = stella
+repository = stable
+
+[c3]
+username = yourname
+api_key = yourapikey

--- a/Tools/PC/oem-qa-checkbox-installer/oem-qa-checkbox-installer.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/oem-qa-checkbox-installer.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# make all files in bin/ executable
+chmod +x ./bin/*
+
+# Get CID, secure ID, SKU info from C3
+./bin/get-id-info.py
+
+# Set up environment
+./bin/env-setup.sh
+
+# Install checkbox
+./bin/boxer.py
+
+#Install other essential packages
+./bin/install-packages.sh
+
+# Get hardware info
+./bin/get-hw-info.sh
+
+# Print out hardware info
+cat ./hardware_info.txt
+
+# Remove boxer.conf
+rm ./conf/setting.conf
+
+# Copy plainbox.conf to the following path
+printf "\nCopying plainbox.conf to ~/.conf and /etc/xdg ...\n"
+sudo cp ./conf/plainbox.conf "$HOME"/.config/
+sudo cp ./conf/plainbox.conf /etc/xdg/
+
+while true; do
+    read -r -p "Press 'r' to reboot or 'e' to exit: " rse
+    case $rse in
+        [Rr]* ) reboot;;
+        [Ee]* ) exit;;
+        * ) echo "Please answer 'r' or 'e'.";;
+    esac
+done


### PR DESCRIPTION
## Summary
This is a tool to help us setup test environment and download checkbox.
The main purpose for this PR is to **migrate oem-qa-installer** to here and also fix some small bugs. If there are some bug won't affect this script, I will fix it in the future PR.

## In this PR, I did the following things
1. Migrate all files related to oem-qa-checkbox-installer to here.
2. Split the big old main script into several small python and shell script, so we could easily maintain it in the future.
3. Add wpa3 to `plainbox.conf`.
4. Adjust the path to config file in `boxer.py`.
5. Add `Remove setting.conf` at the end of script because it contains personal info.
6. Add `Install openssh-server` to ssh to DUT.

## TBD
Refactor boxer.py cause it is a little bit outdated, and some parameters are not even using.