### PR TITLE
Change to multiple MAC in one BTDEVADDR

### DIFF
--- a/Tools/PC/oem-qa-checkbox-installer/conf/plainbox.conf
+++ b/Tools/PC/oem-qa-checkbox-installer/conf/plainbox.conf
@@ -15,9 +15,7 @@ OPEN_N_SSID = cert-n-open-tel-l3-01
 OPEN_AC_SSID = cert-ac-open-tel-l3-01
 OPEN_AX_SSID = cert-ax-open-tel-l3-01
 # === Select one BTDEVADDR below ===
-BTDEVADDR = 7C:B2:7D:4B:14:95
-# BTDEVADDR = 28:3A:4D:46:79:C0
-# BTDEVADDR = 34:6F:24:A8:93:EE
+BTDEVADDR = 7C:B2:7D:4B:14:95,28:3A:4D:46:79:C0,34:6F:24:A8:93:EE,80:32:53:D8:0D:1E
 # ==================================
 TRANSFER_SERVER = cdimage.ubuntu.com
 TEST_TARGET_IPERF = 10.102.182.100,10.102.182.137,10.102.182.101,10.102.182.48

--- a/Tools/PC/oem-qa-checkbox-installer/conf/plainbox.conf
+++ b/Tools/PC/oem-qa-checkbox-installer/conf/plainbox.conf
@@ -14,8 +14,6 @@ OPEN_BG_SSID = cert-bg-open-tel-l3-01
 OPEN_N_SSID = cert-n-open-tel-l3-01
 OPEN_AC_SSID = cert-ac-open-tel-l3-01
 OPEN_AX_SSID = cert-ax-open-tel-l3-01
-# === Select one BTDEVADDR below ===
 BTDEVADDR = 7C:B2:7D:4B:14:95,28:3A:4D:46:79:C0,34:6F:24:A8:93:EE,80:32:53:D8:0D:1E
-# ==================================
 TRANSFER_SERVER = cdimage.ubuntu.com
 TEST_TARGET_IPERF = 10.102.182.100,10.102.182.137,10.102.182.101,10.102.182.48


### PR DESCRIPTION
Since CQT-2031 has merged into checkbox and released  in 2.6, we could change the default palinbox.conf of oem-qa-tools to multiple MAC in one BTDEVADDR style.
