### PR TITLE
Set default repository to "testing"

### DIFF
--- a/Tools/PC/oem-qa-checkbox-installer/README.md
+++ b/Tools/PC/oem-qa-checkbox-installer/README.md
@@ -19,7 +19,7 @@ and also other essential packages.
    3. `api_key`:
       1. Get your api key from [here](https://certification.canonical.com/me).
    4. `provider`: `stella`, `somerville` or `sutton`.
-   5. `repository`: `stable`, `testing` or `daily`.
+   5. `repository`: `stable`, `testing` or `daily`(QA should use `testing` as default).
 4. Run command `$ sh oem-qa-checkbox-installer.sh`.
 5. Follow the instructions of the script.
 6. Test environment setup done! Now you can run `stella-cli`, `somerville-cli`

--- a/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
@@ -75,7 +75,7 @@ def main():
     username = boxercfg["username"]
     ppa_password = boxercfg["ppa_password"]
     provider = args.provider or boxercfg["provider"]
-    repository = args.repository or boxercfg["repository"] or "stable"
+    repository = args.repository or boxercfg["repository"] or "testing"
 
     pre_install()
     # We remove any existing PPA before adding the new ones

--- a/Tools/PC/oem-qa-checkbox-installer/conf/setting.conf
+++ b/Tools/PC/oem-qa-checkbox-installer/conf/setting.conf
@@ -2,7 +2,7 @@
 username = yourname
 ppa_password = yourppapwd
 provider = stella
-repository = stable
+repository = testing
 
 [c3]
 username = yourname


### PR DESCRIPTION
# Description
According to the instructions from cert team, QA team members should use `testing` repository for regular testing.