### PR TITLE
Add to set current user to autologin while oem checkbox installation.

### DIFF
--- a/Tools/PC/oem-qa-checkbox-installer/bin/autologin.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/autologin.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################
+# Purpose:
+# This script is used to set user enbale auto login automatically
+################################################################
+
+NEW_USER="$1"
+CONFIG_FILE="/etc/gdm3/custom.conf"
+if [ -e "${CONFIG_FILE}" ]; then
+    AUTOLOGIN=$(grep "^[^#\[]" "${CONFIG_FILE}"| grep "AutomaticLoginEnable" | cut -d '=' -f 2)
+    if [[ -z ${AUTOLOGIN} ]]; then
+        echo "Set user [${NEW_USER}] to auto login"
+        sed -i "s/\[daemon\]/[daemon]\nAutomaticLoginEnable=True\nAutomaticLogin=${NEW_USER}/1" "${CONFIG_FILE}"
+    elif [[ ${AUTOLOGIN} == "True" ]]; then
+        CUR_USER=$(grep "^[^#\[]" "${CONFIG_FILE}" | grep "AutomaticLogin=" | cut -d '=' -f 2)
+        echo "Changing auto login user from [${CUR_USER}] to [${NEW_USER}]"
+	sed -i "s/AutomaticLogin=${CUR_USER}/AutomaticLogin=${NEW_USER}/1" "${CONFIG_FILE}"
+    else
+        CUR_USER=$(grep "^[^#\[]" "${CONFIG_FILE}" | grep "AutomaticLogin=" | cut -d '=' -f 2)
+        echo "Set user [${NEW_USER}] to auto login"
+	sed -i "s/AutomaticLoginEnable=${AUTOLOGIN}/AutomaticLoginEnable=True/1" "${CONFIG_FILE}"
+	sed -i "s/AutomaticLogin=${CUR_USER}/AutomaticLogin=${NEW_USER}/1" "${CONFIG_FILE}"
+    fi
+else
+    echo "There is no gdm3 setting file:[${CONFIG_FILE}] in this system"
+fi

--- a/Tools/PC/oem-qa-checkbox-installer/bin/env-setup.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/env-setup.sh
@@ -15,17 +15,13 @@ APT::Periodic::Unattended-Upgrade "0";
 EOF
 echo -e "\033[1;42;37mdone\033[0m"
 
-# Disable auto suspend when plugged in
-echo -e "\033[1;32mDisable auto suspend when plugged in\033[0m"
-# Settings > Power > Power > Automatic Suspend > Plugged in > Off
-gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type nothing && echo -e "\033[1;42;37mdone\033[0m"
+# back up dconf setting
+echo -e "\033[1;32mBack up gnome setting by dconf dump\033[0m"
+dconf dump / > ./conf/env-for-restore-dconf
 
-# Disable auto suspend when on battery power
-echo -e "\033[1;32mDisable auto suspend when on battery\033[0m"
-# Settings > Power > Power > Automatic Suspend > On Battery Power > Off
-gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type nothing && echo -e "\033[1;42;37mdone\033[0m"
+# change dconf setting for checkbox testing
+echo -e "\033[1;32mChanging setting by dconf load\033[0m"
+dconf load / < ./conf/checkbox-testing-env-dconf
 
-# Disable auto blank screen
-echo -e "\033[1;32mDisable auto blank screen\033[0m"
-# Settings > Privacy > Screen > Blank Screen Delay > Never
-gsettings set org.gnome.desktop.session idle-delay 0 && echo -e "\033[1;42;37mdone\033[0m"
+# set current to be autologing
+sudo ./bin/autologin.sh $(whoami)

--- a/Tools/PC/oem-qa-checkbox-installer/bin/env-setup.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/env-setup.sh
@@ -24,4 +24,4 @@ echo -e "\033[1;32mChanging setting by dconf load\033[0m"
 dconf load / < ./conf/checkbox-testing-env-dconf
 
 # set current to be autologing
-sudo ./bin/autologin.sh $(whoami)
+sudo ./bin/autologin.sh "$(whoami)"

--- a/Tools/PC/oem-qa-checkbox-installer/conf/checkbox-testing-env-dconf
+++ b/Tools/PC/oem-qa-checkbox-installer/conf/checkbox-testing-env-dconf
@@ -1,0 +1,20 @@
+[org/gnome/settings-daemon/plugins/power]
+# Disable auto suspend when plugged in
+# Settings > Power > Power > Automatic Suspend > Plugged in > Off
+sleep-inactive-ac-type='nothing'
+# Disable auto suspend when on battery power
+# Settings > Power > Power > Automatic Suspend > On Battery Power > Off
+sleep-inactive-battery-type='nothing'
+
+[org/gnome/desktop/screensaver]
+# Disable automatic screen lock
+# Settings > Privacy > Screen > Automatic Screen Lock > off
+lock-enabled=false
+# Disable lock on suspend
+# Settings > Privacy > Screen > Lock Screen on Suspend > off
+ubuntu-lock-on-suspend=false
+
+[org/gnome/desktop/session]
+# Disable auto blank screen
+# Settings > Privacy > Screen > Blank Screen Delay > Never
+idle-delay=uint32 0


### PR DESCRIPTION
Add to set current user to autologin and change to use dconf load to set testing environment to make it easier to restore.
While installation, it will dump all dconf configuration to `env-for-restore-dconf` and could be restored by `dconf load / < env-for-restore-dconf`