### PR TITLE
Upgrade pyYAML to 6.0.1 for python 3.10+

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,4 +63,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1


### PR DESCRIPTION
The pyYAML 5.4.1 is too old for python 3.10+, therefore we have to upgrade it to 6.0.1