### PR TITLE
Update TELOPS DUT Send To Cert card sourced from the CQT card

### DIFF
--- a/Tools/PC/transfer-hw-to-cert/README.md
+++ b/Tools/PC/transfer-hw-to-cert/README.md
@@ -7,8 +7,9 @@ Please see this [Jira Card](https://warthogs.atlassian.net/browse/CQT-1912) for 
 ## How To Use
 
 <!-- markdownlint-configure-file { "MD013": { "line_length": 100 } } -->
-This tool is depend on [Jira](https://github.com/canonical/oem-qa-tools/blob/main/API/Jira) and
-[GoogleSheet](https://github.com/canonical/oem-qa-tools/blob/main/API/GoogleSheet) APIs services.
+This tool is depend on [Jira](https://github.com/canonical/oem-qa-tools/blob/main/API/Jira),
+[GoogleSheet](https://github.com/canonical/oem-qa-tools/blob/main/API/GoogleSheet) and
+[C3](https://certification.canonical.com/me/) APIs services.
 
 Please see [example section](#example) to learn how to use it.
 

--- a/Tools/PC/transfer-hw-to-cert/handlers/cert_team_google_sheet_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cert_team_google_sheet_handler.py
@@ -173,7 +173,6 @@ def are_candidated_sheet_cells_empty(
     """
     all_empty = True
     non_empty_list = []
-    identical_list = []
     for d in data:
         lab = parse_location(d['location']).get('Lab', None)
         if not lab or lab not in sheet_data:
@@ -193,15 +192,8 @@ def are_candidated_sheet_cells_empty(
                 'row_index': indexed_table[d['location']]['row_index'],
                 'location': d['location']
             })
-        elif indexed_cid == d['cid']:
-            message = (f"The \'{d['cid']}\' has filled in the column")
-            identical_list.append({
-                'message': message,
-                'row_index': indexed_table[d['location']]['row_index'],
-                'location': d['location']
-            })
 
-    return all_empty, non_empty_list, identical_list
+    return all_empty, non_empty_list
 
 
 def fill_in_google_sheet(data: list[dict], sheet_data: dict) -> bool:
@@ -288,14 +280,12 @@ def update_cert_lab_google_sheet(data: list[dict]) -> dict:
     sheet_data = get_sheet_data()
 
     # Check those cells are empty
-    empty, non_empty_list, identical_list = are_candidated_sheet_cells_empty(
+    empty, non_empty_list = are_candidated_sheet_cells_empty(
         data,
         sheet_data
     )
 
     if not empty:
-        if identical_list:
-            ("equal_list is not empty")
         raise Exception(
             f"Error: some cells aren't empty. Non empty list: {non_empty_list}"
         )

--- a/Tools/PC/transfer-hw-to-cert/handlers/cert_team_google_sheet_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cert_team_google_sheet_handler.py
@@ -173,26 +173,35 @@ def are_candidated_sheet_cells_empty(
     """
     all_empty = True
     non_empty_list = []
+    identical_list = []
     for d in data:
         lab = parse_location(d['location']).get('Lab', None)
         if not lab or lab not in sheet_data:
             raise Exception(f"Error: Lab \'{lab}\' is not in indexed table")
         # get the indexed table of specific lab
         indexed_table = sheet_data[lab]['indexed_table']
+        indexed_cid = indexed_table[d['location']]['CID']
         # check the CID cell is not empty
-        if indexed_table[d['location']]['CID']:
+        if indexed_cid and indexed_cid != d['cid']:
             all_empty = False
             message = (
                 f"try to fill \'{d['cid']}\' in the CID cell but there\'s "
-                f"\'{indexed_table[d['location']]['CID']}\' occupies the cell"
+                f"\'{indexed_cid}\' occupies the cell"
             )
             non_empty_list.append({
                 'message': message,
                 'row_index': indexed_table[d['location']]['row_index'],
                 'location': d['location']
             })
+        elif indexed_cid == d['cid']:
+            message = (f"The \'{d['cid']}\' has filled in the column")
+            identical_list.append({
+                'message': message,
+                'row_index': indexed_table[d['location']]['row_index'],
+                'location': d['location']
+            })
 
-    return all_empty, non_empty_list
+    return all_empty, non_empty_list, identical_list
 
 
 def fill_in_google_sheet(data: list[dict], sheet_data: dict) -> bool:
@@ -279,12 +288,14 @@ def update_cert_lab_google_sheet(data: list[dict]) -> dict:
     sheet_data = get_sheet_data()
 
     # Check those cells are empty
-    empty, non_empty_list = are_candidated_sheet_cells_empty(
+    empty, non_empty_list, identical_list = are_candidated_sheet_cells_empty(
         data,
         sheet_data
     )
 
     if not empty:
+        if identical_list:
+            ("equal_list is not empty")
         raise Exception(
             f"Error: some cells aren't empty. Non empty list: {non_empty_list}"
         )

--- a/Tools/PC/transfer-hw-to-cert/handlers/hic_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/hic_handler.py
@@ -13,6 +13,7 @@ def query_database() -> dict:
                 "00:be:43:bd:cf:16": "TRM-DVT1-L10-C1_202304-31528"
             }
     """
+    mapping = {}
     try:
         response = requests.request(
             'GET',
@@ -22,8 +23,10 @@ def query_database() -> dict:
             response.raise_for_status()
         return response.json()
     except Exception as e:
-        print(f"Unable to query the HIC database. Error: {e}")
-        raise
+        print(f"====Unable to query the HIC database.==== "
+              f"Please check your connection. Error: {e}")
+
+    return mapping
 
 
 def delete_duts(cids: list[str]) -> None:
@@ -80,4 +83,4 @@ def delete_duts(cids: list[str]) -> None:
                 print(f"Error: Unable to remove {d['sku_name']} ({mac})")
                 print(e)
     if not success:
-        raise Exception('Error: Some DUTs cannot be removed from HIC!')
+        print('Error: Some DUTs cannot be removed from HIC!')

--- a/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
@@ -4,12 +4,13 @@
 
 import json
 
-from Jira.apis.base import JiraAPI, get_jira_members
+from Jira.apis.base import JiraAPI
 
 
 def create_send_dut_to_cert_card_in_telops(
         cqt_card: str,
-        reporter: str,
+        description_original_data: object,
+        assignee_original_id: object,
         data: list
         ) -> None:
     """ Create card to TELOPS board for contractor using, the type of card is
@@ -29,7 +30,6 @@ def create_send_dut_to_cert_card_in_telops(
                     },
                 ]
     """
-    qa_members = get_jira_members()
     issue_updates = []  # Put tasks in this list
 
     telops_jira_api = JiraAPI(
@@ -45,15 +45,17 @@ def create_send_dut_to_cert_card_in_telops(
         # Assign Summary
         fields['summary'] = f"Send CID#{d['cid']} to Cert Lab"
 
+        # Assign Description
+        fields['description'] = description_original_data
+
         # Assign Reporter
-        fields['reporter']['id'] = qa_members[reporter]['jira_uid']
+        fields['reporter']['id'] = assignee_original_id
 
         # Link task back to CQT task
         update_link = telops_jira_api.create_link_issue_content(
             target_issues=[{'key': cqt_card}])
 
         issue_updates.append({'fields': fields, 'update': update_link})
-
     response = telops_jira_api.create_issues(
         payload={'issueUpdates': issue_updates})
     if not response.ok:

--- a/Tools/PC/transfer-hw-to-cert/main.py
+++ b/Tools/PC/transfer-hw-to-cert/main.py
@@ -65,31 +65,27 @@ def main():
                 if not is_valid_location(d['location']):
                     raise Exception(
                         f'Error: Invalid Location in Jira Card {key}')
-
             # Update Cert Lab Google Sheet
             gm_image_link = data['gm_image_link']
             for d in data['data']:
                 d['gm_image_link'] = gm_image_link
-
             print('-' * 5 + 'Updating Cert Lab Google Sheet' + '-' * 5)
             update_cert_lab_google_sheet(data['data'])
-
             # Update DUT holder and location on C3
             print('-' * 5 + 'Updating C3' + '-' * 5)
             update_duts_info_on_c3(
                 data=data['data'], new_holder=args.c3_holder)
-
             # Remove DUTs from HIC site
             print('-' * 5 + 'Removing from HIC' + '-' * 5)
             delete_duts_from_hic(cids=[d['cid'] for d in data['data']])
-
         # Create Jira card to TELOPS board
         # No matter the process is qa_process or contractor process
         # There's always need cards in TELOPS board
         print('-' * 5 + 'Creating card to TELOPS board' + '-' * 5)
         create_send_dut_to_cert_card_in_telops(
             cqt_card=key,
-            reporter=data['qa_launchpad_id'],
+            description_original_data=data['description_original_data'],
+            assignee_original_id=data['assignee_original_id'],
             data=data['data']
         )
 

--- a/Tools/PC/transfer-hw-to-cert/tests/test_cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/tests/test_cqt_handler.py
@@ -66,10 +66,8 @@ class GetContentFromAJiraCardTest(unittest.TestCase):
         sys.stdout = sys.__stdout__
 
     @patch('handlers.cqt_handler.api_get_jira_card')
-    # @patch('handlers.cqt_handler.get_jira_members')
     def test_can_get_valid_content(
         self,
-        # mock_get_jira_members,
         mock_api_get_jira_card
     ):
         """ Should get valid data from hw transfer jira card
@@ -79,10 +77,6 @@ class GetContentFromAJiraCardTest(unittest.TestCase):
         # 'Test result' in Vic's Sandbox project
         mock_api_get_jira_card.return_value = [
             VALID_RESULT_FROM_API, 'customfield_10186']
-
-        # mock_get_jira_members.return_value = {
-        #    'fake-valid-launchpad_id': {}
-        # }
 
         expected_result = VALID_CONTENT_FROM_API
 

--- a/Tools/PC/transfer-hw-to-cert/tests/test_cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/tests/test_cqt_handler.py
@@ -66,10 +66,10 @@ class GetContentFromAJiraCardTest(unittest.TestCase):
         sys.stdout = sys.__stdout__
 
     @patch('handlers.cqt_handler.api_get_jira_card')
-    @patch('handlers.cqt_handler.get_jira_members')
+    # @patch('handlers.cqt_handler.get_jira_members')
     def test_can_get_valid_content(
         self,
-        mock_get_jira_members,
+        # mock_get_jira_members,
         mock_api_get_jira_card
     ):
         """ Should get valid data from hw transfer jira card
@@ -80,9 +80,9 @@ class GetContentFromAJiraCardTest(unittest.TestCase):
         mock_api_get_jira_card.return_value = [
             VALID_RESULT_FROM_API, 'customfield_10186']
 
-        mock_get_jira_members.return_value = {
-            'fake-valid-launchpad_id': {}
-        }
+        # mock_get_jira_members.return_value = {
+        #    'fake-valid-launchpad_id': {}
+        # }
 
         expected_result = VALID_CONTENT_FROM_API
 
@@ -112,7 +112,8 @@ class GetCandidateDutsTest(unittest.TestCase):
         mock_get_content_from_a_jira_card.return_value = {
             'table': [1, 2],
             'gm_image_link': '',
-            'qa_launchpad_id': ''
+            'description_original_data': '',
+            'assignee_original_id': '',
         }
 
         with self.assertRaisesRegex(
@@ -130,8 +131,103 @@ class GetCandidateDutsTest(unittest.TestCase):
             VALID_CONTENT_FROM_API
 
         expected_result = {
-            'gm_image_link': 'https://oem-share.canonical.com/partners/sutton/share/bachman/sutton-workstation-2022-10-07/pc-sutton-bachman-focal-amd64-X00-20221004-139.iso',  # noqa: E501
-            'qa_launchpad_id': 'fake-valid-launchpad_id',
+            "gm_image_link": "https://oem-share.canonical.com/partners/sutton/share/bachman/sutton-workstation-2022-10-07/pc-sutton-bachman-focal-amd64-X00-20221004-139.iso",  # noqa: E501
+            "assignee_original_id": "accountID",
+            "description_original_data": {
+                "content": [
+                    {
+                        "content": [
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "Summary: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "text": "The units are certified, note the \
+                                  details and transfer to cert team.",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "QA Certified Process Guide: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "marks": [
+                                     {
+                                         "attrs": {"href": "docuemnt"},
+                                         "type": "link"
+                                     }
+                                 ],
+                                 "text": "QA Certified Process Guide",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "Certify Planning: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "marks": [
+                                     {
+                                         "attrs": {"href": "https://123.com"},
+                                         "type": "link"
+                                     },
+                                     {
+                                         "type": "strong"
+                                     }
+                                 ],
+                                 "text": "123abc",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "GM Image Path: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "marks": [
+                                     {
+                                         "attrs": {"href": "https://oem-share.\
+                                                   canonical.com/partners/sutton/share/bachman\
+                                                   /sutton-workstation-2022-10-07\
+                                                   /pc-sutton-bachman-focal-amd64-\
+                                                   X00-20221004-139.iso"},
+                                         "type": "link"
+                                     }
+                                 ],
+                                 "text": "https://oem-share.canonical.com\
+                                    /partners/sutton/share/bachman/sutton-workstation-2022-10-07\
+                                    /pc-sutton-bachman-focal-amd64-\
+                                    X00-20221004-139.iso",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "SKU details : ",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             }
+                             ],
+                        "type": 'doc',
+                        "version": 1
+                    }
+                ]
+            },
             "data": [
                 {
                     "cid": "202305-24689",
@@ -158,6 +254,7 @@ class GetCandidateDutsTest(unittest.TestCase):
 
         test_result = get_candidate_duts(key='any')
 
+        self.maxDiff = None
         self.assertEqual(expected_result, test_result)
 
 

--- a/Tools/PC/transfer-hw-to-cert/tests/test_data/jira_card_handler_data.py
+++ b/Tools/PC/transfer-hw-to-cert/tests/test_data/jira_card_handler_data.py
@@ -604,7 +604,102 @@ VALID_RESULT_FROM_API = {
 # VALID_CONTENT_FROM_API is the valid output from get_content_from_a_jira_card function # noqa: E501
 VALID_CONTENT_FROM_API = {
   "gm_image_link": "https://oem-share.canonical.com/partners/sutton/share/bachman/sutton-workstation-2022-10-07/pc-sutton-bachman-focal-amd64-X00-20221004-139.iso",    # noqa: E501
-  "qa_launchpad_id": "fake-valid-launchpad_id",
+  "assignee_original_id": "accountID",
+  "description_original_data": {
+                "content": [
+                    {
+                        "content": [
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "Summary: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "text": "The units are certified, note the \
+                                  details and transfer to cert team.",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "QA Certified Process Guide: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "marks": [
+                                     {
+                                         "attrs": {"href": "docuemnt"},
+                                         "type": "link"
+                                     }
+                                 ],
+                                 "text": "QA Certified Process Guide",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "Certify Planning: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "marks": [
+                                     {
+                                         "attrs": {"href": "https://123.com"},
+                                         "type": "link"
+                                     },
+                                     {
+                                         "type": "strong"
+                                     }
+                                 ],
+                                 "text": "123abc",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "GM Image Path: ",
+                                 "type": "text"
+                             },
+                             {
+                                 "marks": [
+                                     {
+                                         "attrs": {"href": "https://oem-share.\
+                                                   canonical.com/partners/sutton/share/bachman\
+                                                   /sutton-workstation-2022-10-07\
+                                                   /pc-sutton-bachman-focal-amd64-\
+                                                   X00-20221004-139.iso"},
+                                         "type": "link"
+                                     }
+                                 ],
+                                 "text": "https://oem-share.canonical.com\
+                                    /partners/sutton/share/bachman/sutton-workstation-2022-10-07\
+                                    /pc-sutton-bachman-focal-amd64-\
+                                    X00-20221004-139.iso",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             },
+                             {
+                                 "marks": [{"type": "strong"}],
+                                 "text": "SKU details : ",
+                                 "type": "text"
+                             },
+                             {
+                                 "type": "hardBreak"
+                             }
+                             ],
+                        "type": 'doc',
+                        "version": 1
+                    }
+                ]
+   },
   "table": [
     {
       "type": "tableRow",


### PR DESCRIPTION
Enhance the description details to Jira TELOPS DUT Send To Cert card from the CQT hardware transfer card. Additionally, update the reporter of the TELOPS card to match the assignee of CQT card.

https://warthogs.atlassian.net/browse/CQT-3130 

1. Copy the CQT content to TELOPS card.
2. Remove ''qa_launchpad_id''.
3. Modify: if the CID has already exist in the google_sheet, it will not raise the exception.
4. Bypass if the HIC connection is down.