### PR TITLE
[jira-card-creator] Change primary_key to platform_tag for sutton

### DIFF
--- a/Tools/PC/jira-card-creator/pc_platform_tracker.py
+++ b/Tools/PC/jira-card-creator/pc_platform_tracker.py
@@ -568,7 +568,7 @@ def combine_duplicate_tag(data, primary_key):
 def generate_platform_records(projects):
     payload = {}
     for project in projects:
-        if project in ["stella", "sutton"]:
+        if project in ["stella"]:
             primary_key = "lp_tag"
         else:
             # by default, we will group record by platform code name


### PR DESCRIPTION
### Summary
since lp_tag which is retrieved from **Offical Tag** column in Sutton's project book is no longer available
use platform_tag as primary_key instead

### Fix 
#36 different platforms in sutton are combined into one record

### Test result
http://10.102.135.50:8080/view/qa-services/job/qa-create-pc-jira-card/173/console