### PR TITLE
Update Jira TELOPS DUT Send To Cert card with QA LAB status

### DIFF
--- a/API/Jira/apis/base.py
+++ b/API/Jira/apis/base.py
@@ -456,6 +456,19 @@ class JiraAPI:
 
         return response
 
+    def make_transition(self, issue_key, transition_id):
+        transition_url = (
+            f"{self._base_url}/{self._jira_api_path}/issue/{issue_key}")
+        transition_data = {
+            'transition': {
+                'id': transition_id
+            }
+        }
+        response = self._request(
+            'POST', url=transition_url, payload=transition_data)
+
+        return response
+
 
 def get_jira_members():
     """ Get the members who have the permission to access the Jira Project

--- a/API/Jira/apis/base.py
+++ b/API/Jira/apis/base.py
@@ -457,8 +457,18 @@ class JiraAPI:
         return response
 
     def make_transition(self, issue_key, transition_id):
+        """ Make a transition on a Jira issue identified by its key.
+
+            Parameters:
+                issue_key (str): The key of the Jira issue to transition.
+
+            Returns:
+                requests.Response: The HTTP response object containing the
+                result of the transition.
+        """
         transition_url = (
-            f"{self._base_url}/{self._jira_api_path}/issue/{issue_key}")
+            f"{self._base_url}/{self._jira_api_path}/issue/{issue_key}"
+            f"/transitions")
         transition_data = {
             'transition': {
                 'id': transition_id

--- a/Tools/PC/transfer-hw-to-cert/configs/jira_telops.json
+++ b/Tools/PC/transfer-hw-to-cert/configs/jira_telops.json
@@ -3,5 +3,8 @@
     "key": "VS",
     "issue_type": {
         "DUT_Send_To_Cert": "11730"
+    },
+    "transition_data": {
+        "To Do QA LAB": "2"
     }
 }

--- a/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
@@ -62,13 +62,17 @@ def create_send_dut_to_cert_card_in_telops(
     if response.ok:
         print(json.dumps(response.json(), indent=2))
         print('Created the following cards to TELOPS board successfully')
-        created_issues = response.json()['issues']
-        transition_id = '2'
-        for created_issue in created_issues:
-            transition_url = f"{created_issue['key']}/transitions"
-            response = telops_jira_api.make_transition(
-                transition_url, transition_id)
 
+        # Get the transition ID number which is from the TELOPS board
+        transition_id = telops_jira_api.jira_project['transition_data'][
+            'To Do QA LAB']
+
+        created_issues = response.json()['issues']
+
+        for created_issue in created_issues:
+            # Assign status with 'To Do QA LAB'
+            response = telops_jira_api.make_transition(
+                created_issue['key'], transition_id)
     else:
         print('*' * 50)
         print(json.dumps(issue_updates, indent=2))

--- a/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
@@ -58,12 +58,21 @@ def create_send_dut_to_cert_card_in_telops(
         issue_updates.append({'fields': fields, 'update': update_link})
     response = telops_jira_api.create_issues(
         payload={'issueUpdates': issue_updates})
-    if not response.ok:
+
+    if response.ok:
+        print(json.dumps(response.json(), indent=2))
+        print('Created the following cards to TELOPS board successfully')
+        created_issues = response.json()['issues']
+        transition_id = '2'
+        for created_issue in created_issues:
+            transition_url = f"{created_issue['key']}/transitions"
+            response = telops_jira_api.make_transition(
+                transition_url, transition_id)
+
+    else:
         print('*' * 50)
         print(json.dumps(issue_updates, indent=2))
         raise Exception(
             'Error: Failed to create card to TELOPS board',
             f"Reason: {response.text}"
         )
-    print('Created the following cards to TELOPS board successfully')
-    print(json.dumps(response.json(), indent=2))


### PR DESCRIPTION
**Summary**
Improving the Jira card for TELOPS status based on its creation from a CQT Jira card enables cert team members identifying the card's classification.

**Test Result:**
From Cert team request https://warthogs.atlassian.net/browse/CQT-3501.
Need to change the status while creating the TELOPS card with "To Do: QA Lab" status from CQT board.
The "To Do: QA Lab" transition id on TELOPS board is "2", the details can be found in the CQT-3501.

