### PR TITLE
Fix the #42 hw transfer to cert team which is causing the key error

### DIFF
--- a/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/telops_handler.py
@@ -64,8 +64,8 @@ def create_send_dut_to_cert_card_in_telops(
         print('Created the following cards to TELOPS board successfully')
 
         # Get the transition ID number which is from the TELOPS board
-        transition_id = telops_jira_api.jira_project['transition_data'][
-            'To Do QA LAB']
+        transition_data = telops_jira_api.jira_project['transition_data']
+        transition_id = transition_data.get('To Do QA LAB')
 
         created_issues = response.json()['issues']
 


### PR DESCRIPTION
Trail run the test that didn't meet the issue, but running on Jenkins which is causing the key error.

Log:
Created the following cards to TELOPS board successfully
Traceback (most recent call last):
  File "/root/oem-qa-tools/transfer-hw-to-cert/main.py", line 113, in <module>
    main()
  File "/root/oem-qa-tools/transfer-hw-to-cert/main.py", line 85, in main
    create_send_dut_to_cert_card_in_telops(
  File "/root/oem-qa-tools/transfer-hw-to-cert/handlers/telops_handler.py", line 67, in create_send_dut_to_cert_card_in_telops
    transition_id = telops_jira_api.jira_project['transition_data'][
KeyError: 'transition_data'
Build step 'Execute shell' marked build as failure