### PR TITLE
While using MaaS deployed DUTs in Cert Lab, the systemd_analyze is fa…

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/00_initial
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/00_initial
@@ -57,4 +57,7 @@ _run gsettings set org.gnome.desktop.screensaver lock-enabled false
 _run gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'nothing'
 _run gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type 'nothing'
 _run gsettings set org.gnome.desktop.session idle-delay 'uint32 0'
+# stop and disable pc-sanity-backgroud-photo.service that from SWE for mass deploy
+_run sudo systemctl stop pc-sanity-backgroud-photo.service
+_run sudo systemctl disable pc-sanity-backgroud-photo.service
 


### PR DESCRIPTION
While using MaaS deployed DUTs in Cert Lab, the systemd_analyze is failed for waiting pc-sanity-backgroud-photo.service. However, this is unnecessary service for normal users. Therefore, disable it before testing would be better and no impact for other DUTs that deployed by other methods.