### PR TITLE
Update the project key ID by incorporating the new board.

### DIFF
--- a/API/Jira/configs/jira_config/project.json
+++ b/API/Jira/configs/jira_config/project.json
@@ -1,19 +1,23 @@
 {
-    "id": "10350",
-    "key": "VS",
-    "name": "Vic's Sandbox",
+    "id": "11030",
+    "key": "OEMQA",
+    "name": "OEM QA Team-ENG",
     "issue_type": {
-        "Task": "10635",
-        "Story": "10634",
-        "DUT_Send_To_Cert": "11730"
+        "Task": "10013",
+        "Bug": "10015",
+        "Story": "10002",
+        "Objective": "10390",
+        "Spike": "10037",
+        "Epic": "10000",
+        "DUT_Send_To_Cert": "10796"
     },
     "epic": {
-        "Somerville": "69110",
-        "Stella": "69111",
-        "Sutton": "69112",
-        "Tooling & Process": "63215"
+        "Dell": "55134",
+        "Hp": "55135",
+        "Lenovo": "55136",
+        "Tooling & Process": "55347"
     },
     "card_fields": {
-        "Test result": "customfield_10186"
+        "Acceptance Criteria": "customfield_10614"
     }
 }

--- a/Tools/PC/transfer-hw-to-cert/configs/jira_telops.json
+++ b/Tools/PC/transfer-hw-to-cert/configs/jira_telops.json
@@ -1,8 +1,8 @@
 {
-    "id": "10350",
-    "key": "VS",
+    "id": "10382",
+    "key": "TELOPS",
     "issue_type": {
-        "DUT_Send_To_Cert": "11730"
+        "DUT_Send_To_Cert": "10796"
     },
     "transition_data": {
         "To Do QA LAB": "2"

--- a/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
@@ -8,7 +8,8 @@ from Jira.apis.base import JiraAPI
 
 
 def get_content_from_a_jira_card(key: str) -> dict:
-    """ Get the content from the 'Test result' field in a specific Jira card.
+    """ Get the content from the 'Acceptance Criteria' field
+        in a specific Jira card.
 
         @param:key, the key of jira card. e.g. CQT-1234
 
@@ -36,7 +37,7 @@ def get_content_from_a_jira_card(key: str) -> dict:
     # only one issue is expected.
     # By design, the "Description" field is the default field
     # in each Jira card.
-    # By design, the "Test result" field is the default field
+    # By design, the "Acceptance Criteria" field is the default field
     # in each Jira card on CQT Jira project.
     description_field = response['issues'][0]['fields']['description']
     assignee_info = response['issues'][0]['fields'].get('assignee', {})
@@ -113,15 +114,15 @@ def api_get_jira_card(key: str) -> tuple[dict, str]:
         'fields': [
             'description',
             'assignee',
-            jira_api.jira_project['card_fields']['Test result']
+            jira_api.jira_project['card_fields']['Acceptance Criteria']
         ],
     }
     response = jira_api.get_issues(payload=payload)
     parsed = json.loads(response.text)
 
-    # By design, the "Test result" field is the default field
+    # By design, the "Acceptance Criteria" field is the default field
     # in each Jira card on QA's Jira project
-    return parsed, jira_api.jira_project['card_fields']['Test result']
+    return parsed, jira_api.jira_project['card_fields']['Acceptance Criteria']
 
 
 def retrieve_row_data(data: dict) -> list:


### PR DESCRIPTION
Follow the new company-owned board with associated IDs for projects and fields. Adjust the key IDs and column names in current applications accordingly.

Jira Card: https://warthogs.atlassian.net/browse/OEMQA-3371

Test results (only test two configs):
https://warthogs.atlassian.net/browse/OEMQA-700
https://warthogs.atlassian.net/browse/TELOPS-817
https://warthogs.atlassian.net/browse/TELOPS-818
