### PR TITLE
Update the jira card field name by incorporating the new board.

### DIFF
--- a/API/Jira/configs/jira_config/project.json
+++ b/API/Jira/configs/jira_config/project.json
@@ -14,6 +14,7 @@
         "Tooling & Process": "63215"
     },
     "card_fields": {
-        "Test result": "customfield_10186"
+        "Acceptance Criteria": "customfield_10675",
+        "Test Results": "customfield_10186"
     }
 }

--- a/API/Jira/scenarios/pc/pc.py
+++ b/API/Jira/scenarios/pc/pc.py
@@ -625,7 +625,7 @@ class QaPcJira():
             self._generate_transfer_cert_description())
 
         # Add the content into the Test Result field
-        fields[self.jira_api.jira_project['card_fields']['Test result']] = {
+        fields[self.jira_api.jira_project['card_fields']['Test Results']] = {
             "version": 1,
             "type": "doc",
             "content": TEMPLATE_TEST_RESULT_FIELD

--- a/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
@@ -8,7 +8,8 @@ from Jira.apis.base import JiraAPI
 
 
 def get_content_from_a_jira_card(key: str) -> dict:
-    """ Get the content from the 'Test result' field in a specific Jira card.
+    """ Get the content from the 'Test Results' field
+        in a specific Jira card.
 
         @param:key, the key of jira card. e.g. CQT-1234
 
@@ -36,7 +37,7 @@ def get_content_from_a_jira_card(key: str) -> dict:
     # only one issue is expected.
     # By design, the "Description" field is the default field
     # in each Jira card.
-    # By design, the "Test result" field is the default field
+    # By design, the "Test Results" field is the default field
     # in each Jira card on CQT Jira project.
     description_field = response['issues'][0]['fields']['description']
     assignee_info = response['issues'][0]['fields'].get('assignee', {})
@@ -113,15 +114,15 @@ def api_get_jira_card(key: str) -> tuple[dict, str]:
         'fields': [
             'description',
             'assignee',
-            jira_api.jira_project['card_fields']['Test result']
+            jira_api.jira_project['card_fields']['Test Results']
         ],
     }
     response = jira_api.get_issues(payload=payload)
     parsed = json.loads(response.text)
 
-    # By design, the "Test result" field is the default field
+    # By design, the "Test Results" field is the default field
     # in each Jira card on QA's Jira project
-    return parsed, jira_api.jira_project['card_fields']['Test result']
+    return parsed, jira_api.jira_project['card_fields']['Test Results']
 
 
 def retrieve_row_data(data: dict) -> list:


### PR DESCRIPTION
Follow the new company-owned board with associated name for fields. Adjust the column names in current applications accordingly.

Test Result:
https://warthogs.atlassian.net/browse/TELOPS-817
https://warthogs.atlassian.net/browse/TELOPS-818

