### PR TITLE
Change checkbox ppa to fit new policy

### DIFF
--- a/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/boxer.py
@@ -14,9 +14,9 @@ PROVIDERS = ("somerville",
              "otaru",
              "wenshan",
              )
-CHECKBOX_REPOS = {"stable": "ppa:hardware-certification/public",
-                  "testing": "ppa:checkbox-dev/testing",
-                  "daily": "ppa:checkbox-dev/ppa"}
+CHECKBOX_REPOS = {"stable": "ppa:checkbox-dev/stable",
+                  "testing": "ppa:checkbox-dev/beta",
+                  "daily": "ppa:checkbox-dev/edge"}
 FWTS_REPO = "ppa:firmware-testing-team/ppa-fwts-stable"
 PC_ENABLE_REPO = "ppa:oem-solutions-engineers/pc-enablement-tools"
 OEM_REPO = "https://{username}:{password}@private-ppa.launchpad.net/" \

--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/02_Install_checkbox_deb
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/02_Install_checkbox_deb
@@ -4,8 +4,8 @@ _run sudo apt-get -qq purge -y checkbox-ng
 _run sudo apt-get -qq purge -y python3-checkbox-*
 _run sudo apt-get -qq purge -y plainbox-provider-*
 _run sudo apt-get -qq purge -y checkbox-provider-*
-_run sudo add-apt-repository --remove -y ppa:checkbox-dev/ppa
-_run sudo add-apt-repository ppa:checkbox-dev/testing -y
+_run sudo add-apt-repository --remove -y ppa:checkbox-dev/edge
+_run sudo add-apt-repository ppa:checkbox-dev/beta -y
 _run sudo apt-get update
 _run sudo DEBIAN_FRONTEND=noninteractive apt-get install checkbox-provider-base checkbox-ng checkbox-provider-resource checkbox-provider-certification-client -y
 _run checkbox-cli --version


### PR DESCRIPTION
Checkbox PPA has been changed to new policy, and the old one is deprecated.