### PR TITLE
remove sosreport installing from oem-qa-checkbox-installer

### DIFF
--- a/Tools/PC/oem-qa-checkbox-installer/bin/install-packages.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/bin/install-packages.sh
@@ -8,10 +8,6 @@ pwd='u'
 echo "Installing bugit..."
 echo ${pwd} | sudo -S snap install bugit --edge --devmode
 
-# Install sosreport
-echo "Installing sosreport..."
-echo ${pwd} | sudo -S snap install sosreport --classic
-
 # Install openssh
 echo "Installing openssh-server..."
 echo ${pwd} | sudo apt install -y openssh-server


### PR DESCRIPTION
sosreport will failed the test `snappy/test-snaps-confinement`
besides, we have packaged sosreport in bugit, there is no need to install it separately by default