### PR TITLE
Avoid running `oem-qa-checkbox-installer.sh` as root

### DIFF
--- a/Tools/PC/oem-qa-checkbox-installer/oem-qa-checkbox-installer.sh
+++ b/Tools/PC/oem-qa-checkbox-installer/oem-qa-checkbox-installer.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# make sure to use this scrpit by rootless
+if [ "$(whoami)" = "root" ]; then
+    echo "Please don't use root to run this scrpit"
+    exit 1
+fi
+
 # make all files in bin/ executable
 chmod +x ./bin/*
 


### PR DESCRIPTION
Run this script with root will change the autologin user to root and login failed after reboot.
Therefore, check the current user isn't root at beginning to avoid this error.