### PR TITLE
Fix: #61 #62 add valid number in the new lab6 and fix rack locations errors

### DIFF
--- a/Tools/PC/transfer-hw-to-cert/handlers/cert_team_google_sheet_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cert_team_google_sheet_handler.py
@@ -110,7 +110,7 @@ def get_sheet_data() -> dict:
     wanted_headers = [
         'CID', 'Certified_OEM_Image', 'Lab', 'Frame', 'Shelf', 'Partition']
 
-    # t is TEL-L3 or TEL-L5
+    # t is TEL-L3, TEL-L5 or TEL-L6
     for t in GOOGLE_SHEET_CONF['tables']:
         sheet_data[t] = {}
         # Get the first row (a.k.a header), such as CID, Lab, Frame ...

--- a/Tools/PC/transfer-hw-to-cert/tests/test_utils_common.py
+++ b/Tools/PC/transfer-hw-to-cert/tests/test_utils_common.py
@@ -65,6 +65,14 @@ class IsValidLocationTest(unittest.TestCase):
             {
                 'name': 'correct location 2',
                 'location': 'TEL-L3-R01-S10-P0',
+            },
+            {
+                'name': 'correct location 3',
+                'location': 'TEL-L6-F03-S3-P3',
+            },
+            {
+                'name': 'correct location 4',
+                'location': 'TEL-L6-R02-S10-P1',
             }
         ]
 
@@ -113,6 +121,11 @@ class IsValidLocationTest(unittest.TestCase):
                 'location': 'tel-L5-F02-S1-P7',
                 'expect_value': False
             },
+            {
+                'name': 'wrong shelf',
+                'location': 'TEL-L6-F02-S9-P1',
+                'expect_value': False
+            }
         ]
 
         for case in test_cases:
@@ -126,14 +139,32 @@ class ParseLocationTest(unittest.TestCase):
     def test_parse_valid_location(self):
         """ Parse the valid location
         """
-        actual_result = parse_location(location='TEL-L3-F24-S5-P1')
-        expected_result = {
-            'Lab': 'TEL-L3',
-            'Frame': 'F24',
-            'Shelf': '5',
-            'Partition': '1'
-        }
-        self.assertEqual(expected_result, actual_result)
+        test_cases = [
+            {
+                'name': 'correct location',
+                'location': 'TEL-L3-F24-S5-P1',
+                'expected_result': {
+                    'Lab': 'TEL-L3',
+                    'Frame': 'F24',
+                    'Shelf': '5',
+                    'Partition': '1'
+                },
+            },
+            {
+                'name': 'correct location 1',
+                'location': 'TEL-L6-R02-S10-P1',
+                'expected_result': {
+                    'Lab': 'TEL-L6',
+                    'Frame': 'R02',
+                    'Shelf': '10',
+                    'Partition': '1'
+                },
+            },
+        ]
+        for case in test_cases:
+            actual_result = parse_location(case['location'])
+            expected_result = case['expected_result']
+            self.assertEqual(expected_result, actual_result)
 
     def test_parse_invalid_location(self):
         """ Parse the invalid location
@@ -151,7 +182,7 @@ class ParseLocationTest(unittest.TestCase):
         ]
 
         for case in test_cases:
-            actual_result = parse_location(location=case['location'])
+            actual_result = parse_location(case['location'])
             self.assertEqual({}, actual_result)
 
 

--- a/Tools/PC/transfer-hw-to-cert/utils/common.py
+++ b/Tools/PC/transfer-hw-to-cert/utils/common.py
@@ -16,7 +16,10 @@ def is_valid_location(location: str) -> bool:
     """ Check if it's valid of the format of Location
     """
     pattern = re.compile(
-        r'^TEL-L\d-F\d{2}-S\d-P[12]$|^TEL-L\d-R\d{2}-S\d{1,2}-P0$')
+        r'^TEL-(L\d-R\d{2}-S\d{1,2}-P[01]|'
+        r'L[35]-F\d{2}-S[1-5]-P[12]|'
+        r'L[6]-F\d{2}-S[1-8]-P[123])$'
+        )
     return True if re.match(pattern, location) else False
 
 
@@ -32,7 +35,7 @@ def parse_location(location: str) -> dict:
     """ Parse the location data
     """
     part_re = re.compile(
-        '(?P<Lab>TEL-L\d)-(?P<Frame>F\d+)-S(?P<Shelf>\d+)-P(?P<Partition>\d+)'  # noqa: W605, E501
+        '(?P<Lab>TEL-L\d)-(?P<Frame>[FR]\d+)-S(?P<Shelf>\d+)-P(?P<Partition>\d+)'  # noqa: W605, E501
     )
     match = re.search(part_re, location)
     return {} if not match else {

--- a/Tools/PC/transfer-hw-to-cert/utils/common.py
+++ b/Tools/PC/transfer-hw-to-cert/utils/common.py
@@ -16,9 +16,7 @@ def is_valid_location(location: str) -> bool:
     """ Check if it's valid of the format of Location
     """
     pattern = re.compile(
-        r'^TEL-(L\d-R\d{2}-S\d{1,2}-P[01]|'
-        r'L[35]-F\d{2}-S[1-5]-P[12]|'
-        r'L[6]-F\d{2}-S[1-8]-P[123])$'
+        r'^TEL-(L\d-R\d{2}-S\d{1,2}-P[01]|L[356]-F\d{2}-S[1-8]-P[123])$'
         )
     return True if re.match(pattern, location) else False
 


### PR DESCRIPTION
Add shelf, frame and partition number for valid location by
following structure specified in the Cert team's google sheet. 

Fix the error that exclude the rack location in parsing locations.

Issue:
https://github.com/canonical/oem-qa-tools/issues/61
https://github.com/canonical/oem-qa-tools/issues/62

Test Result:
https://warthogs.atlassian.net/browse/OEMQA-3824
