### PR TITLE
DUT remove return process

### DIFF
--- a/API/C3/apis/base.py
+++ b/API/C3/apis/base.py
@@ -14,7 +14,7 @@ C3_DIR_PATH = os.path.split(pathlib.Path(__file__).parent.resolve())[0]
 CONF_DIR_PATH = os.path.join(C3_DIR_PATH, 'configs')
 
 
-class TaipeiLocation(Enum):
+class C3Location(Enum):
     """ The location string from C3
     """
     TEL_L1 = 'Taipei Eongher - Lab-1'
@@ -26,6 +26,7 @@ class TaipeiLocation(Enum):
     TEL_L7 = 'Taipei Eongher - Lab-7'
     TEL_OFFICE = 'Taipei Eongher - Lab - Office'
     TAIPEI_OFFCIE = 'Taipei Office'
+    Return = 'Returned to Partner/OEM'
 
 
 @dataclass
@@ -35,7 +36,7 @@ class DUTPayloadAttrs:
         e.g. DUTPayloadAttrs({'holder': '<launchpad_id>'})
     """
     holder: str = None
-    location: TaipeiLocation = None
+    location: C3Location = None
     canonical_contact: str = None
     date_received: str = None
     hardware_build: str = None

--- a/Tools/PC/transfer-hw-to-cert/handlers/c3_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/c3_handler.py
@@ -1,6 +1,6 @@
 import os
 
-from C3.apis.base import C3API, TaipeiLocation
+from C3.apis.base import C3API, C3Location
 from utils.common import parse_location
 
 
@@ -14,16 +14,30 @@ def init_c3_api() -> object:
 
 def update_duts_info_on_c3(data: list[dict], new_holder: str):
     """ Update DUTS' information on C3 webstie
-
         Currently, we update the holder and location
     """
     c3 = init_c3_api()
-
     for dut in data:
         payload = {
             'holder': new_holder,
-            'location': TaipeiLocation[
+            'location': C3Location[
                 parse_location(dut['location'])['Lab'].replace('-', '_')].value
+        }
+        print(f"Updating {dut['cid']}")
+        res = c3.update_dut_by_cid(cid=dut['cid'], payload=payload)
+        if res.status_code < 200 or res.status_code > 299:
+            raise Exception('Error: update failed')
+
+
+def update_returned_duts_info_on_c3(data: list[dict], status: str):
+    """ Update DUTS' information on C3 website
+        For the returned DUTs, we update the location and the status
+    """
+    c3 = init_c3_api()
+    for dut in data:
+        payload = {
+            'location': C3Location.Return.value,
+            'status': status,
         }
         print(f"Updating {dut['cid']}")
         res = c3.update_dut_by_cid(cid=dut['cid'], payload=payload)

--- a/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
@@ -18,7 +18,7 @@ def get_content_from_a_jira_card(key: str) -> dict:
                  'VALID_CONTENT_FROM_API' in tests/testdata
     """
     # Get the content of specific Jira card via API
-    ##response, test_result_field_id = api_get_jira_card(key)
+
     response, _ = api_get_jira_card(key)
     if 'errorMessages' in response:
         print(response['errorMessages'][0])
@@ -43,32 +43,13 @@ def get_content_from_a_jira_card(key: str) -> dict:
     description_field = response['issues'][0]['fields']['description']
     assignee_info = response['issues'][0]['fields'].get('assignee', {})
     assignee_id = assignee_info.get('accountId', '')
-    ##test_result_field = response['issues'][0]['fields'][test_result_field_id]
 
     # Return dictionary
     re_dict = {
         'description_original_data': description_field,
         'assignee_original_id': assignee_id,
         'gm_image_link': '',
-    ##    'table': []
     }
-
-    # Retrieve candidate DUT info from table
-    ##try:
-    ##    table_idx = None
-    ##    for idx in range(len(test_result_field['content'])):
-    ##        # Find the index fo 'table' dict in the content list
-    ##        if 'type' in test_result_field['content'][idx] and \
-    ##                test_result_field['content'][idx]['type'] == 'table':
-    ##            table_idx = idx
-    ##            break
-    ##    # Get the content list from table dict
-    ##    table_content = test_result_field['content'][table_idx]['content']
-    ##    re_dict['table'] = table_content
-    ##except Exception as e:
-    ##    print(e)
-    ##    raise Exception(
-    ##        f"Error: Failed to get the table content from card '{key}'")
 
     # Get the link of gm image
     try:
@@ -96,7 +77,6 @@ def get_content_from_a_jira_card(key: str) -> dict:
         print(
             f"Warning: Failed to get the GM Image Path from card '{key}'")
 
-    #print("RRRRre_CONTENTdict:", re_dict)
     return re_dict
 
 
@@ -155,7 +135,7 @@ def get_result_table_from_a_jira_card(key: str) -> dict:
         raise Exception(
             f"Error: Failed to get the table content from card '{key}'")
 
-    return re_dict  
+    return re_dict
 
 
 def api_get_jira_card(key: str) -> tuple[dict, str]:
@@ -231,8 +211,12 @@ def get_candidate_duts(key: str) -> dict:
     # Return dictionary
     re_dict = {
         'data': [],
-        'description_original_data': content_description['description_original_data'],
-        'assignee_original_id': content_description['assignee_original_id'],
+        'description_original_data': content_description[
+            'description_original_data'
+            ],
+        'assignee_original_id': content_description[
+            'assignee_original_id'
+            ],
         'gm_image_link': content_description['gm_image_link'],
     }
 
@@ -261,7 +245,6 @@ def get_candidate_duts(key: str) -> dict:
         }
         re_dict['data'].append(tmp_d)
 
-    #print("RRRRre_dict:", re_dict)
     return re_dict
 
 
@@ -271,12 +254,13 @@ def get_returned_cid_info_from_a_jira(key: str) -> list:
         @return: List of CID strings
         ['202212-12345', '202212-12366']
     """
-    #content = get_content_from_a_jira_card(key)
     content = get_result_table_from_a_jira_card(key)
     cid_list = []
-    for row in content['table'][2:]:  # Start from the third row to skip header and example row
+    for row in content['table'][2:]:
+        # Start from the third row to skip header and example row
         data = retrieve_row_data(row)
-        if data[0]:  # If CID is not empty in the row, add it to the list
-            cid_list.append(data[0])#
-    print('Get Returned CID List:', cid_list )
+        if data[0]:
+            # If CID is not empty in the row, add it to the list
+            cid_list.append(data[0])
+    print('Get Returned CID List:', cid_list)
     return cid_list

--- a/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
@@ -96,6 +96,7 @@ def get_content_from_a_jira_card(key: str) -> dict:
         print(
             f"Warning: Failed to get the GM Image Path from card '{key}'")
 
+    #print("RRRRre_CONTENTdict:", re_dict)
     return re_dict
 
 
@@ -260,6 +261,7 @@ def get_candidate_duts(key: str) -> dict:
         }
         re_dict['data'].append(tmp_d)
 
+    #print("RRRRre_dict:", re_dict)
     return re_dict
 
 

--- a/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/cqt_handler.py
@@ -18,7 +18,8 @@ def get_content_from_a_jira_card(key: str) -> dict:
                  'VALID_CONTENT_FROM_API' in tests/testdata
     """
     # Get the content of specific Jira card via API
-    response, test_result_field_id = api_get_jira_card(key)
+    ##response, test_result_field_id = api_get_jira_card(key)
+    response, _ = api_get_jira_card(key)
     if 'errorMessages' in response:
         print(response['errorMessages'][0])
         raise Exception(
@@ -42,32 +43,32 @@ def get_content_from_a_jira_card(key: str) -> dict:
     description_field = response['issues'][0]['fields']['description']
     assignee_info = response['issues'][0]['fields'].get('assignee', {})
     assignee_id = assignee_info.get('accountId', '')
-    test_result_field = response['issues'][0]['fields'][test_result_field_id]
+    ##test_result_field = response['issues'][0]['fields'][test_result_field_id]
 
     # Return dictionary
     re_dict = {
         'description_original_data': description_field,
         'assignee_original_id': assignee_id,
         'gm_image_link': '',
-        'table': []
+    ##    'table': []
     }
 
     # Retrieve candidate DUT info from table
-    try:
-        table_idx = None
-        for idx in range(len(test_result_field['content'])):
-            # Find the index fo 'table' dict in the content list
-            if 'type' in test_result_field['content'][idx] and \
-                    test_result_field['content'][idx]['type'] == 'table':
-                table_idx = idx
-                break
-        # Get the content list from table dict
-        table_content = test_result_field['content'][table_idx]['content']
-        re_dict['table'] = table_content
-    except Exception as e:
-        print(e)
-        raise Exception(
-            f"Error: Failed to get the table content from card '{key}'")
+    ##try:
+    ##    table_idx = None
+    ##    for idx in range(len(test_result_field['content'])):
+    ##        # Find the index fo 'table' dict in the content list
+    ##        if 'type' in test_result_field['content'][idx] and \
+    ##                test_result_field['content'][idx]['type'] == 'table':
+    ##            table_idx = idx
+    ##            break
+    ##    # Get the content list from table dict
+    ##    table_content = test_result_field['content'][table_idx]['content']
+    ##    re_dict['table'] = table_content
+    ##except Exception as e:
+    ##    print(e)
+    ##    raise Exception(
+    ##        f"Error: Failed to get the table content from card '{key}'")
 
     # Get the link of gm image
     try:
@@ -96,6 +97,64 @@ def get_content_from_a_jira_card(key: str) -> dict:
             f"Warning: Failed to get the GM Image Path from card '{key}'")
 
     return re_dict
+
+
+def get_result_table_from_a_jira_card(key: str) -> dict:
+    """ Get the content from the 'Test Results' field
+        in a specific Jira card.
+
+        @param:key, the key of jira card. e.g. CQT-1234
+
+        @return, table list. Please see the value of
+                 'VALID_TABLE_FROM_API' in tests/testdata
+    """
+    # Get the content of specific Jira card via API
+    response, test_result_field_id = api_get_jira_card(key)
+    if 'errorMessages' in response:
+        print(response['errorMessages'][0])
+        raise Exception(
+            f"Error: Failed to get the card '{key}'. "
+            f"{response['errorMessages'][0]}"
+        )
+
+    # Check if only one issue we got
+    if len(response['issues']) != 1:
+        raise Exception(
+            f"Error: expect only 1 jira issue "
+            f"but got {response['issues']} issues"
+        )
+
+    # Index is 0 because we search the Jira card by key,
+    # only one issue is expected.
+    # By design, the "Description" field is the default field
+    # in each Jira card.
+    # By design, the "Test Results" field is the default field
+    # in each Jira card on CQT Jira project.
+    test_result_field = response['issues'][0]['fields'][test_result_field_id]
+
+    # Return dictionary
+    re_dict = {
+        'table': []
+    }
+
+    # Retrieve candidate DUT info from table
+    try:
+        table_idx = None
+        for idx in range(len(test_result_field['content'])):
+            # Find the index fo 'table' dict in the content list
+            if 'type' in test_result_field['content'][idx] and \
+                    test_result_field['content'][idx]['type'] == 'table':
+                table_idx = idx
+                break
+        # Get the content list from table dict
+        table_content = test_result_field['content'][table_idx]['content']
+        re_dict['table'] = table_content
+    except Exception as e:
+        print(e)
+        raise Exception(
+            f"Error: Failed to get the table content from card '{key}'")
+
+    return re_dict  
 
 
 def api_get_jira_card(key: str) -> tuple[dict, str]:
@@ -165,14 +224,15 @@ def get_candidate_duts(key: str) -> dict:
             }]
         }
     """
-    content = get_content_from_a_jira_card(key)
+    content_description = get_content_from_a_jira_card(key)
+    content_table = get_result_table_from_a_jira_card(key)
 
     # Return dictionary
     re_dict = {
         'data': [],
-        'description_original_data': content['description_original_data'],
-        'assignee_original_id': content['assignee_original_id'],
-        'gm_image_link': content['gm_image_link'],
+        'description_original_data': content_description['description_original_data'],
+        'assignee_original_id': content_description['assignee_original_id'],
+        'gm_image_link': content_description['gm_image_link'],
     }
 
     # Sanitize each dut
@@ -183,14 +243,14 @@ def get_candidate_duts(key: str) -> dict:
     #     - idx 0 is table's header
     #     - idx 1, aka row 1, is the example placeholder
     #   So the real data should be started from idx 2
-    if len(content['table']) < 3:
+    if len(content_table['table']) < 3:
         raise Exception(
             f"Error: expect more than 2 rows in table "
-            f"but got {len(content['table'])}"
+            f"but got {len(content_table['table'])}"
         )
 
-    for i in range(2, len(content['table'])):
-        data = retrieve_row_data(content['table'][i])
+    for i in range(2, len(content_table['table'])):
+        data = retrieve_row_data(content_table['table'][i])
         # Filter out empty row. data[0] is cid, data[1] is location
         if not data[0] and not data[1]:
             continue
@@ -201,3 +261,20 @@ def get_candidate_duts(key: str) -> dict:
         re_dict['data'].append(tmp_d)
 
     return re_dict
+
+
+def get_returned_cid_info_from_a_jira(key: str) -> list:
+    """ Get CID information from a specific Jira Card
+        @param:key, the key of Jira card. e.g. CQT-1234
+        @return: List of CID strings
+        ['202212-12345', '202212-12366']
+    """
+    #content = get_content_from_a_jira_card(key)
+    content = get_result_table_from_a_jira_card(key)
+    cid_list = []
+    for row in content['table'][2:]:  # Start from the third row to skip header and example row
+        data = retrieve_row_data(row)
+        if data[0]:  # If CID is not empty in the row, add it to the list
+            cid_list.append(data[0])#
+    print('Get Returned CID List:', cid_list )
+    return cid_list

--- a/Tools/PC/transfer-hw-to-cert/tests/test_cqt_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/tests/test_cqt_handler.py
@@ -1,6 +1,4 @@
 import unittest
-import io
-import sys
 from unittest.mock import patch
 
 # Make sure mock_import must need to be imported before our own modules

--- a/Tools/PC/transfer-hw-to-cert/tests/test_data/jira_card_handler_data.py
+++ b/Tools/PC/transfer-hw-to-cert/tests/test_data/jira_card_handler_data.py
@@ -699,7 +699,10 @@ VALID_CONTENT_FROM_API = {
                         "version": 1
                     }
                 ]
-   },
+   }
+}
+# VALID_TABLE_FROM_API is the valid output from get_result_table_from_a_jira_card function # noqa: E501
+VALID_TABLE_FROM_API = {
   "table": [
     {
       "type": "tableRow",

--- a/Tools/PC/transfer-hw-to-cert/tests/test_data/jira_card_handler_data.py
+++ b/Tools/PC/transfer-hw-to-cert/tests/test_data/jira_card_handler_data.py
@@ -1045,33 +1045,6 @@ VALID_TABLE_FROM_API = {
   ]
 }
 
-# The result who doesn't contains the table in "Test result" field.
-# This one can be used to mimic that users triggers wrong Jira card,
-# non "HW transfer to cert lab" card, so we should expect there's no any
-# "table" related data in this dictionary.
-EMPTY_TABLE_RESULT_FROM_API = {
-    "expand": "names,schema",
-    "startAt": 0,
-    "maxResults": 50,
-    "total": 1,
-    "issues": [
-        {
-            "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",  # noqa: E501
-            "id": "192827",
-            "self": "https://warthogs.atlassian.net/rest/api/3/issue/192827",
-            "key": "VS-2645",
-            "fields": {
-                "description": {
-                    "type": "doc",
-                    "version": 1,
-                    "content": []
-                },
-                "customfield_10186": None
-            }
-        }
-    ]
-}
-
 # A single row data whose CID and Location are valid
 VALID_ROW_DATA = {
     'type':


### PR DESCRIPTION
Add return process in HW transfer tools.

The commit introduces the return process in the HW transfer tools,
1. separate the content and test result, making it more flexible to use.
2. allowing automatic changes to the C3 status when DUTs are no longer necessary,
such as the SI or DVT1 phases.
This automation streamlines the workflow and ensures accurate status updates.

Test: https://warthogs.atlassian.net/browse/OQS-3309