### PR TITLE
Add plainbox-provider-pc-sanity and install checkbox on agent

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/02_Install_checkbox_deb
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/02_Install_checkbox_deb
@@ -7,6 +7,8 @@ _run sudo apt-get -qq purge -y checkbox-provider-*
 _run sudo add-apt-repository --remove -y ppa:checkbox-dev/edge
 _run sudo add-apt-repository ppa:checkbox-dev/beta -y
 _run sudo apt-get update
-_run sudo DEBIAN_FRONTEND=noninteractive apt-get install checkbox-provider-base checkbox-ng checkbox-provider-resource checkbox-provider-certification-client -y
+_run sudo DEBIAN_FRONTEND=noninteractive apt-get install checkbox-provider-base checkbox-ng checkbox-provider-resource checkbox-provider-certification-client plainbox-provider-pc-sanity -y
 _run checkbox-cli --version
 
+# we are testing using debs on the dut
+CHECKBOX_CLI_CMD="checkbox-cli"

--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/02_Install_checkbox_snap
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/02_Install_checkbox_snap
@@ -3,3 +3,5 @@ _run sudo snap remove checkbox20
 _run sudo snap install checkbox20
 _run sudo snap install checkbox --channel=latest/stable --classic
 
+# we are testing using snaps on the dut
+CHECKBOX_CLI_CMD="checkbox.checkbox-cli"

--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/15_install_checkbox_on_agent
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/15_install_checkbox_on_agent
@@ -1,0 +1,14 @@
+# Install the checkbox controller.
+# The controller has to come from the ppa:checkbox-dev/beta
+# which is equivalent to the beta channel in the snap store
+# this way the versions will match
+sudo add-apt-repository -y ppa:checkbox-dev/beta
+sudo apt update
+sudo DEBIAN_FRONTEND=noninteractive apt install -yqq checkbox-ng
+
+echo "Installing checkbox in agent container"
+CHECKBOX_VERSION=$(_run $CHECKBOX_CLI_CMD --version)
+git clone --depth=1 https://github.com/canonical/hwcert-jenkins-tools.git > /dev/null
+git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
+hwcert-jenkins-tools/version-published/checkout_to_version.py ~/checkbox "$CHECKBOX_VERSION"
+(cd checkbox/checkbox-ng || return; sudo python3 setup.py install > /dev/null)

--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/90_start_test
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/90_start_test
@@ -1,5 +1,5 @@
 echo "Starting Test"
-PYTHONUNBUFFERED=1 checkbox-cli remote "$DEVICE_IP" checkbox-launcher
+PYTHONUNBUFFERED=1 checkbox-cli control "$DEVICE_IP" checkbox-launcher
 EXITCODE=$?
 echo EXITCODE: "$EXITCODE"
 echo "Copy submission tar file to artifacts folder"


### PR DESCRIPTION
**Changes:**
1. Added plainbox-provider-pc-sanity in templates to be installed on DUT. This provider is now hosted on [checkbox beta](https://launchpad.net/~checkbox-dev/+archive/ubuntu/beta), so no need to install pc sanity ppa
2. Added template to install checkbox-ng on agent, then switch to specific version to match with DUT. This code was copied from Cert team Jenkins and adjusted to agent env.
3. Use "control" instead of "remote"


**Test:**
- Run shellcheck against new templates
- Run [infrastructure-checkbox-run-debug](http://10.131.60.220:8080/job/infrastructure-checkbox-run-debug/102/) job, which clones this repo and generates the job.yaml (Note: there are some errors when switching checkbox version, but the same errors are found in cert teams SRU job. So I assume those are not relevant)