### PR TITLE
testflinger-yaml-generator: add provision parameters for oem_autoinstall connector

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
+++ b/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
@@ -344,14 +344,20 @@ def parse_input_arg():
                           ie, desktop-22-04-2-uefi. \
                           If didn\'t set this mean no provision')
     opt_args.add_argument('--provisionToken', default="", type=str,
-                          help='File with username and token for image \
-                          URL auth')
+                          help='Optional file with username and token \
+                          when image URL requires authentication \
+                          (i.e Jenkins artifact). This file must be \
+                          in YAML format, i.e: \
+                          \"username: $JENKINS_USERNAME \\n \
+                          token: $JENKINS_API_TOKEN\"')
     opt_args.add_argument('--provisionUserData', default="", type=str,
                           help='user-data file for autoinstall and cloud-init \
-                          provisioning')
+                          provisioning. This argument is a MUST required \
+                          if deploy the image using the autoinstall image \
+                          (i.e. 24.04 image)')
     opt_args.add_argument('--provisionAuthKeys', default="", type=str,
-                          help='authorized_keys file to add in provisioned \
-                          system')
+                          help='ssh authorized_keys file to add in \
+                          provisioned system')
     opt_args.add_argument('--globalTimeout', type=int, default=43200,
                           help="Set the testflinger's global timeout. \
                           Max:43200")

--- a/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
+++ b/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
@@ -263,8 +263,8 @@ class TFYamlBuilder(YamlGenerator, TestCommandGenerator):
         self.is_distupgrade = is_distupgrade
 
     def provision_setting(self, is_provision, image="desktop-22-04-2-uefi",
-                          provision_type="distro", provision_token=None,
-                          provision_auth_keys=None, provision_user_data=None):
+                          provision_type="distro", provision_token="",
+                          provision_auth_keys="", provision_user_data=""):
         if not is_provision:
             self.yaml_remove_field("provision_data")
             return
@@ -279,7 +279,8 @@ class TFYamlBuilder(YamlGenerator, TestCommandGenerator):
             setting_dict['provision_data']['token_file'] = provision_token
             attachments.append({'local': provision_token})
         if provision_auth_keys:
-            setting_dict['provision_data']['authorized_keys'] = provision_auth_keys
+            setting_dict['provision_data'][
+                'authorized_keys'] = provision_auth_keys
             attachments.append({'local': provision_auth_keys})
         if attachments:
             setting_dict['provision_data']['attachments'] = attachments
@@ -343,11 +344,14 @@ def parse_input_arg():
                           ie, desktop-22-04-2-uefi. \
                           If didn\'t set this mean no provision')
     opt_args.add_argument('--provisionToken', default="", type=str,
-                           help='File with username and token for image URL auth')
+                          help='File with username and token for image \
+                          URL auth')
     opt_args.add_argument('--provisionUserData', default="", type=str,
-                           help='user-data file for autoinstall and cloud-init provisioning')
+                          help='user-data file for autoinstall and cloud-init \
+                          provisioning')
     opt_args.add_argument('--provisionAuthKeys', default="", type=str,
-                           help='authorized_keys file to add in provisioned system')
+                          help='authorized_keys file to add in provisioned \
+                          system')
     opt_args.add_argument('--globalTimeout', type=int, default=43200,
                           help="Set the testflinger's global timeout. \
                           Max:43200")

--- a/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
+++ b/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
@@ -263,11 +263,27 @@ class TFYamlBuilder(YamlGenerator, TestCommandGenerator):
         self.is_distupgrade = is_distupgrade
 
     def provision_setting(self, is_provision, image="desktop-22-04-2-uefi",
-                          provision_type="distro"):
+                          provision_type="distro", provision_token=None,
+                          provision_auth_keys=None, provision_user_data=None):
         if not is_provision:
             self.yaml_remove_field("provision_data")
             return
         setting_dict = {'provision_data': {provision_type: image}}
+
+        # additional parameters if use oem_autoinstall connector
+        attachments = []
+        if provision_user_data:
+            setting_dict['provision_data']['user_data'] = provision_user_data
+            attachments.append({'local': provision_user_data})
+        if provision_token:
+            setting_dict['provision_data']['token_file'] = provision_token
+            attachments.append({'local': provision_token})
+        if provision_auth_keys:
+            setting_dict['provision_data']['authorized_keys'] = provision_auth_keys
+            attachments.append({'local': provision_auth_keys})
+        if attachments:
+            setting_dict['provision_data']['attachments'] = attachments
+
         self.yaml_update_field(setting_dict)
 
     def reserve_setting(self, is_reserve, lp_username, timeout=120):
@@ -326,6 +342,12 @@ def parse_input_arg():
                           help='The provision image. \
                           ie, desktop-22-04-2-uefi. \
                           If didn\'t set this mean no provision')
+    opt_args.add_argument('--provisionToken', default="", type=str,
+                           help='File with username and token for image URL auth')
+    opt_args.add_argument('--provisionUserData', default="", type=str,
+                           help='user-data file for autoinstall and cloud-init provisioning')
+    opt_args.add_argument('--provisionAuthKeys', default="", type=str,
+                           help='authorized_keys file to add in provisioned system')
     opt_args.add_argument('--globalTimeout', type=int, default=43200,
                           help="Set the testflinger's global timeout. \
                           Max:43200")
@@ -392,7 +414,10 @@ if __name__ == "__main__":
 
     builder.provision_setting(is_provision=provision,
                               image=args.provisionImage,
-                              provision_type=args.provisionType)
+                              provision_type=args.provisionType,
+                              provision_token=args.provisionToken,
+                              provision_user_data=args.provisionUserData,
+                              provision_auth_keys=args.provisionAuthKeys)
 
     builder.reserve_setting(is_reserve=reserve,
                             lp_username=args.LpID,


### PR DESCRIPTION
Expand tf-yaml-generator to support [oem_autoinstall device connector](https://github.com/canonical/testflinger/pull/304) in 24.04.
It adds 3 more parameters + attachments in the provision stage of job.yaml. These parameters are optional, so if args not added, then no changes to original behavior and templates.

Sample provisioning data for 24.04:

```
job_queue: artur-oemscript-2404
provision_data:
  url: http://10.131.60.220:8080/job/somerville-noble-oem-24.04a/lastSuccessfulBuild/artifact/out/somerville-noble-oem-24.04a-20240806-59.iso
  token_file: "jenkins-token.txt"
  user_data: "ubuntu-oem-image-builder/alloem-init/cloud-configs/redeploy/user-data"
  authorized_keys: "ubuntu-oem-image-builder/injections/alloem-init/chroot/minimal.standard.live.hotfix.squashfs/etc/ssh/authorized_keys"
  attachments:
    - local: "ubuntu-oem-image-builder/alloem-init/cloud-configs/redeploy/user-data"
    - local: "ubuntu-oem-image-builder/injections/alloem-init/chroot/minimal.standard.live.hotfix.squashfs/etc/ssh/authorized_keys"
    - local: "jenkins-token.txt"
```
Test:
generate with original args:
`./testflinger_yaml_generator.py -c 202405-33980 -o prov.yaml --LpID artur-at-work --provisionImage http://10.131.60.220:8080/job/somerville-noble-oem-24.04a/lastSuccessfulBuild/artifact/out/somerville-noble-oem-24.04a-20240820-71.iso`

`./testflinger_yaml_generator.py -c 202405-33980 -o prov-url.yaml --LpID artur-at-work --provisionType url --provisionImage http://10.131.60.220:8080/job/somerville-noble-oem-24.04a/lastSuccessfulBuild/artifact/out/somerville-noble-oem-24.04a-20240820-71.iso`

generate with new args:
`./testflinger_yaml_generator.py -c 202405-33980 -o prov-new.yaml --LpID artur-at-work --provisionType url --provisionImage http://10.131.60.220:8080/job/somerville-noble-oem-24.04a/lastSuccessfulBuild/artifact/out/somerville-noble-oem-24.04a-20240820-71.iso --provisionToken ~/testflinger/test-yaml/jenkins-token.txt --provisionAuthKeys ~/testflinger/test-yaml/authorized_keys --provisionUserData ~/testflinger/test-yaml/user-data`

[Sample prov-new.yaml](https://pastebin.canonical.com/p/GVj6fNVkxd/)

Closes: https://warthogs.atlassian.net/browse/OEX86-412