### PR TITLE
TFG: change method of submiting checkbox submission

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/launcher_config/main.conf
+++ b/Tools/PC/testflinger_yaml_generator/template/launcher_config/main.conf
@@ -8,21 +8,12 @@ type = silent
 [daemon]
 normal_user = ubuntu
 
-[transport:c3]
-type = submission-service
-secure_id = $HEXR_DEVICE_SECURE_ID
-
 [transport:local_file]
 type = file
 path = /home/ubuntu/c3-local-submission.tar.xz
 
 [exporter:tar]
 unit = com.canonical.plainbox::tar
-
-[report:report_c3]
-transport = c3
-exporter = tar
-forced = yes
 
 [report:report_file]
 transport = local_file

--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/90_start_test
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/90_start_test
@@ -4,18 +4,21 @@ EXITCODE=$?
 echo CHECKBOX EXITCODE: "$EXITCODE"
 
 SESSION_DESC="CE-QA-PC_Test"
-FILE_PATH="/home/ubuntu/c3-local-submission.tar.xz"
+SUBMISSION_TAR_PATH="/home/ubuntu/c3-local-submission.tar.xz"
 MAXLOOP=20
 COUNT=0
 
 # Check if the file exists
-if [ ! -f "$FILE_PATH" ]; then
-    echo "Submission tar file not found: $FILE_PATH"
+if [ ! -f "$SUBMISSION_TAR_PATH" ]; then
+    echo "Submission tar file not found: $SUBMISSION_TAR_PATH"
     exit 1
 fi
 
+echo "Move submission tar file to artifacts folder"
+mv "$SUBMISSION_TAR_PATH" artifacts/
+
 while [ $COUNT -lt $MAXLOOP ]; do
-    RET=$(checkbox-cli submit -m "$SESSION_DESC" "$HEXR_DEVICE_SECURE_ID" "$FILE_PATH")
+    RET=$(checkbox-cli submit -m "$SESSION_DESC" "$HEXR_DEVICE_SECURE_ID" artifacts/c3-local-submission.tar.xz)
     if [[ $RET == *"Successfully"* ]]; then
         echo "Found 'Successfully' in output."
         echo "$RET" > "artifacts/submission_url.log"
@@ -31,8 +34,6 @@ if [ $COUNT -ge $MAXLOOP ]; then
     exit 1
 fi
 
-echo "Move submission tar file to artifacts folder"
-mv "$FILE_PATH" artifacts/
 echo "Files in artifacts:"
 ls artifacts
 

--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/90_start_test
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/90_start_test
@@ -2,8 +2,37 @@ echo "Starting Test"
 PYTHONUNBUFFERED=1 checkbox-cli control "$DEVICE_IP" checkbox-launcher
 EXITCODE=$?
 echo CHECKBOX EXITCODE: "$EXITCODE"
-echo "Copy submission tar file to artifacts folder"
-mv /home/ubuntu/c3-local-submission.tar.xz artifacts/
+
+SESSION_DESC="CE-QA-PC_Test"
+FILE_PATH="/home/ubuntu/c3-local-submission.tar.xz"
+MAXLOOP=20
+COUNT=0
+
+# Check if the file exists
+if [ ! -f "$FILE_PATH" ]; then
+    echo "Submission tar file not found: $FILE_PATH"
+    exit 1
+fi
+
+while [ $COUNT -lt $MAXLOOP ]; do
+    RET=$(checkbox-cli submit -m "$SESSION_DESC" "$HEXR_DEVICE_SECURE_ID" "$FILE_PATH")
+    if [[ $RET == *"Successfully"* ]]; then
+        echo "Found 'Successfully' in output."
+        echo "$RET" > "artifacts/submission_url.log"
+        break
+    else
+        echo "Attempt $((COUNT+1)): 'Successfully' not found."
+    fi
+    COUNT=$((COUNT+1))
+done
+
+if [ $COUNT -ge $MAXLOOP ]; then
+    echo "Maximum attempts reached without success."
+    exit 1
+fi
+
+echo "Move submission tar file to artifacts folder"
+mv "$FILE_PATH" artifacts/
 echo "Files in artifacts:"
 ls artifacts
 

--- a/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
+++ b/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
@@ -230,15 +230,16 @@ class TestCommandGenerator(CheckboxLauncherBuilder):
                     cmd_str += "EOF\n"
             with open(file, "r", encoding="utf-8") as f_file:
                 content = f_file.read().strip()
-                if (
-                    self.default_session_desc != session_desc and
-                    f'SESSION_DESC="{self.default_session_desc}"' in content
-                ):
-                    content = content.replace(
-                        f'SESSION_DESC="{self.default_session_desc}"',
-                        f'SESSION_DESC="{session_desc}"'
-                    )
                 if content:
+                    if (
+                        self.default_session_desc != session_desc
+                        and f'SESSION_DESC="{self.default_session_desc}"'
+                        in content
+                    ):
+                        content = content.replace(
+                            f'SESSION_DESC="{self.default_session_desc}"',
+                            f'SESSION_DESC="{session_desc}"'
+                        )
                     cmd_str += f"{content}\n"
         lines = cmd_str.split("\n")
         cmd_str = "\n".join([line for line in lines if line.strip("\n") != ""])

--- a/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
+++ b/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
@@ -174,6 +174,8 @@ class CheckboxLauncherBuilder(ConfigOperation):
 
 
 class TestCommandGenerator(CheckboxLauncherBuilder):
+    default_session_desc = "CE-QA-PC_Test"
+
     def __init__(self, template_bin_folder="./template/shell_scripts/",
                  launcher_temp_folder="./template/launcher_config"):
         super().__init__(template_folder=launcher_temp_folder)
@@ -196,8 +198,7 @@ class TestCommandGenerator(CheckboxLauncherBuilder):
     def generate_test_cmd(self, manifest_json_path, test_plan_name,
                           exclude_job_pattern_str, is_distupgrade=False,
                           checkbox_type="deb", is_runtest=True,
-                          session_desc="CE-QA-PC_Test"):
-        default_session_desc = "CE-QA-PC_Test"
+                          session_desc=default_session_desc):
         if checkbox_type not in ["deb", "snap"]:
             raise ValueError(f"Checkbox type is not valid. \
                               Expected one of: {checkbox_type}")
@@ -229,9 +230,12 @@ class TestCommandGenerator(CheckboxLauncherBuilder):
                     cmd_str += "EOF\n"
             with open(file, "r", encoding="utf-8") as f_file:
                 content = f_file.read().strip()
-                if f'SESSION_DESC="{default_session_desc}"' in content:
+                if (
+                    self.default_session_desc != session_desc and
+                    f'SESSION_DESC="{self.default_session_desc}"' in content
+                ):
                     content = content.replace(
-                        f'SESSION_DESC="{default_session_desc}"',
+                        f'SESSION_DESC="{self.default_session_desc}"',
                         f'SESSION_DESC="{session_desc}"'
                     )
                 if content:

--- a/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
+++ b/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
@@ -172,9 +172,6 @@ class CheckboxLauncherBuilder(ConfigOperation):
         self.update_section_value("test selection", "exclude",
                                   exclude_job_pattern_str)
 
-    def set_session_desc(self, session_desc="CE-QA-PC_Test"):
-        self.update_section_value("launcher", "session_desc", session_desc)
-
 
 class TestCommandGenerator(CheckboxLauncherBuilder):
     def __init__(self, template_bin_folder="./template/shell_scripts/",
@@ -189,12 +186,10 @@ class TestCommandGenerator(CheckboxLauncherBuilder):
 
     def build_launcher(self, manifest_json_path, test_plan_name,
                        exclude_job_pattern_str, file_path="./final_launcher",
-                       execute_path="/usr/bin/env checkbox-cli",
-                       session_desc="CE-QA-PC_Test"):
+                       execute_path="/usr/bin/env checkbox-cli"):
         self.set_test_plan(test_plan_name)
         self.set_exclude_job(exclude_job_pattern_str)
         self.merge_manifest_json(json_file_path=manifest_json_path)
-        self.set_session_desc(session_desc=session_desc)
         self.generate_config_file(file_path=file_path,
                                   execute_path=execute_path)
 
@@ -202,6 +197,7 @@ class TestCommandGenerator(CheckboxLauncherBuilder):
                           exclude_job_pattern_str, is_distupgrade=False,
                           checkbox_type="deb", is_runtest=True,
                           session_desc="CE-QA-PC_Test"):
+        default_session_desc = "CE-QA-PC_Test"
         if checkbox_type not in ["deb", "snap"]:
             raise ValueError(f"Checkbox type is not valid. \
                               Expected one of: {checkbox_type}")
@@ -222,8 +218,7 @@ class TestCommandGenerator(CheckboxLauncherBuilder):
                 self.build_launcher(manifest_json_path, test_plan_name,
                                     exclude_job_pattern_str,
                                     launcher_file_path,
-                                    "/usr/bin/env checkbox-cli",
-                                    session_desc)
+                                    "/usr/bin/env checkbox-cli")
 
                 with open(launcher_file_path, "r", encoding="utf-8") as l_file:
                     lines = l_file.readlines()
@@ -234,6 +229,11 @@ class TestCommandGenerator(CheckboxLauncherBuilder):
                     cmd_str += "EOF\n"
             with open(file, "r", encoding="utf-8") as f_file:
                 content = f_file.read().strip()
+                if f'SESSION_DESC="{default_session_desc}"' in content:
+                    content = content.replace(
+                        f'SESSION_DESC="{default_session_desc}"',
+                        f'SESSION_DESC="{session_desc}"'
+                    )
                 if content:
                     cmd_str += f"{content}\n"
         lines = cmd_str.split("\n")
@@ -317,6 +317,9 @@ def parse_input_arg():
     opt_args.add_argument('--excludeJobs', type=str, default="",
                           help='Set the exclude jobs pattern. \
                           ie".*memory/memory_stress_ng".')
+    opt_args.add_argument("--sessionDesc", type=str,
+                          default="CE-QA-PC_Test",
+                          help="Set the session description")
     opt_args.add_argument('--checkboxType', choices=["deb", "snap"],
                           default="deb",
                           help="Set which checkbox type you need to \
@@ -337,9 +340,6 @@ def parse_input_arg():
                           timeout.')
 
     opt_launcher = parser.add_argument_group("Launcher settion  options")
-    opt_launcher.add_argument("--sessionDesc", type=str,
-                              default="CE-QA-PC_Test",
-                              help="Set the session description")
     opt_launcher.add_argument("--manifestJson", type=str,
                               default=f"{script_dir}/template/manifest.json",
                               help="Set the manifest json file to build \


### PR DESCRIPTION
Change the submitting checkbox submission way.

make the submit return stored in the `artifacts/submission_url.log`

The original way is using the checkbox auto submission mechanism, and we are hard to get the submission url unless we parser the testflinger output. It will take a long time to get the testflinger output via `testflinger results <UUID>`.

The new way is using the testflinger to help us submit checkbox submission, put the submission_url in a file, and we can download the artifacts via `testflinger artifacts <uuid>`.
Once we need the submission url, we only need to parse the `artifacts/submission_url.log`.

Testflinger UUID: [2cb37d6b-9e8d-4d40-8a8d-b73ecd514096](https://testflinger.canonical.com/jobs/2cb37d6b-9e8d-4d40-8a8d-b73ecd514096) to check the test command field and output.
```
./artifacts
├── c3-local-submission.tar.xz
├── dcd.info
└── submission_url.log

0 directories, 3 files

```
