### PR TITLE
tf-generator: Remove test_data in job.yaml when --testplan is not provided

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
+++ b/Tools/PC/testflinger_yaml_generator/testflinger_yaml_generator.py
@@ -359,6 +359,9 @@ def parse_input_arg():
     opt_args.add_argument('--provisionAuthKeys', default="", type=str,
                           help='ssh authorized_keys file to add in \
                           provisioned system')
+    opt_args.add_argument('--provisionOnly', action='store_true',
+                          help='Run only provisioning without tests. \
+                          Removes test_data before generating the yaml.')
     opt_args.add_argument('--globalTimeout', type=int, default=43200,
                           help="Set the testflinger's global timeout. \
                           Max:43200")
@@ -433,15 +436,19 @@ if __name__ == "__main__":
                               provision_token=args.provisionToken,
                               provision_user_data=args.provisionUserData,
                               provision_auth_keys=args.provisionAuthKeys)
+    if args.provisionOnly:
+        # remove test and reserve stages that were added by default
+        builder.yaml_remove_field("test_data")
+        builder.yaml_remove_field("reserve_data")
+    else:
+        builder.reserve_setting(is_reserve=reserve,
+                                lp_username=args.LpID,
+                                timeout=args.reserveTime)
 
-    builder.reserve_setting(is_reserve=reserve,
-                            lp_username=args.LpID,
-                            timeout=args.reserveTime)
-
-    builder.test_cmd_setting(manifest_json_path=args.manifestJson,
-                             test_plan_name=args.testplan,
-                             exclude_job_pattern_str=args.excludeJobs,
-                             checkbox_type=args.checkboxType,
-                             session_desc=args.sessionDesc)
+        builder.test_cmd_setting(manifest_json_path=args.manifestJson,
+                                 test_plan_name=args.testplan,
+                                 exclude_job_pattern_str=args.excludeJobs,
+                                 checkbox_type=args.checkboxType,
+                                 session_desc=args.sessionDesc)
 
     builder.generate_yaml_file(file_path=TF_yaml_file_path)


### PR DESCRIPTION
Add --provisionOnly flag (Default=False) to generate job.yaml without default test_data stage.
Use case if when need to only provision the DUT without test plan.

**Test:**
Provision only:
`./testflinger_yaml_generator.py -c 202405-33980 -o prov-new.yaml --provisionType url --provisionImage http://10.131.60.220:8080/job/somerville-noble-oem-24.04a/lastSuccessfulBuild/artifact/out/somerville-noble-oem-24.04a-20240820-71.iso --provisionToken ~/testflinger/test-yaml/jenkins-token.txt --provisionAuthKeys ~/testflinger/test-yaml/authorized_keys --provisionUserData ~/testflinger/test-yaml/user-data --provisionOnly`

Test default plan only without provision:
`./testflinger_yaml_generator.py -c 202405-33980 -o prov-new.yaml`

Provision and test default plan:
`./testflinger_yaml_generator.py -c 202405-33980 -o prov-new.yaml --provisionType url --provisionImage http://10.131.60.220:8080/job/somerville-noble-oem-24.04a/lastSuccessfulBuild/artifact/out/somerville-noble-oem-24.04a-20240820-71.iso --provisionToken ~/testflinger/test-yaml/jenkins-token.txt --provisionAuthKeys ~/testflinger/test-yaml/authorized_keys --provisionUserData ~/testflinger/test-yaml/user-data`