### PR TITLE
migrate hostdata to labresource

### DIFF
--- a/Tools/PC/transfer-hw-to-cert/handlers/c3_v2_handler.py
+++ b/Tools/PC/transfer-hw-to-cert/handlers/c3_v2_handler.py
@@ -1,9 +1,9 @@
 import logging
 from modules.c3_relay_service.relay_service import (
-    get_hostdata_list,
-    get_hostdata_id,
-    detach_hostdata,
-    link_hostdata,
+    get_labresource_list,
+    get_labresource_id,
+    detach_labresource,
+    link_labresource,
     LabPosition,
 )
 from utils.common import parse_location
@@ -12,7 +12,7 @@ from utils.common import parse_location
 def update_duts_info_on_c3(data: list[dict], new_holder: str):
     """
     Update DUTS' information on C3 webstie
-    Currently, we detach the old and link the new hostdata
+    Currently, we detach the old and link the new labresource
 
     :data: DUTs information.
 
@@ -20,23 +20,25 @@ def update_duts_info_on_c3(data: list[dict], new_holder: str):
 
     :returns: None
     """
-    hostdatas = get_hostdata_list(None, "DUT")
+    # limit the query in the TEL-L4 and TEL-L10
+    pos = LabPosition("TEL-L4,TEL-L10", None, 0, 0)
+    labresources = get_labresource_list(pos, "DUT")
     for dut in data:
-        cid = dut['cid']
+        cid = dut["cid"]
         logging.info(f"Updating {cid}")
-        # detach hostdata
-        resp = detach_hostdata(cid, hostdatas)
+        # detach labresource
+        resp = detach_labresource(cid, labresources)
         if resp["canonical_id"]:
-            logging.error(f"detach hostdata from CID:{cid} failed")
+            logging.error(f"detach labresource from CID:{cid} failed")
         loc = parse_location(dut["location"])
         pos = LabPosition(
             loc["Lab"], loc["Frame"], int(loc["Shelf"]), int(loc["Partition"])
         )
-        hostdata_id = get_hostdata_id(pos)
-        # link to new hostdata
-        resp = link_hostdata(cid, hostdata_id)
+        labresource_id = get_labresource_id(pos)
+        # link to new labresource
+        resp = link_labresource(cid, labresource_id)
         if resp["canonical_id"] != cid:
-            logging.error(f"link hostdata to CID:{cid} failed")
+            logging.error(f"link labresource to CID:{cid} failed")
         # TODO There is no V2 API to change holder by lunchpad name.
         #      Have to wait or find the solution.
 
@@ -44,7 +46,7 @@ def update_duts_info_on_c3(data: list[dict], new_holder: str):
 def update_returned_duts_info_on_c3(data: list[dict], status: str):
     """
     Update DUTS' information on C3 webstie
-    Currently, we detach the old hostdata and update location and status
+    Currently, we detach the old labresource and update location and status
 
     :data: DUTs information.
 
@@ -52,14 +54,16 @@ def update_returned_duts_info_on_c3(data: list[dict], status: str):
 
     :returns: None
     """
-    hostdatas = get_hostdata_list(None, "DUT")
+    # limit the query in the TEL-L4 and TEL-L10
+    pos = LabPosition("TEL-L4,TEL-L10", None, 0, 0)
+    labresources = get_labresource_list(pos, "DUT")
     for dut in data:
         cid = dut["cid"]
         logging.info(f"Updating {cid}")
-        # detach hostdata
-        resp = detach_hostdata(cid, hostdatas)
+        # detach labresource
+        resp = detach_labresource(cid, labresources)
         if resp["canonical_id"]:
-            logging.error(f"detach hostdata from CID:{cid} failed")
+            logging.error(f"detach labresource from CID:{cid} failed")
         # TODO update status (New V2 API might be needed)
         # TODO There is no V2 API to change location.
         #      Have to wait or find the solution.


### PR DESCRIPTION
This follows up the change of C3 and limit the datacentre to TEL-L4 and TEL-L10 to make C3 to response faster.