### PR TITLE
avoid kernel be updated during test period

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/00_initial
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/00_initial
@@ -52,6 +52,13 @@ echo "$DCD" > artifacts/dcd.info
 echo "Files in artifacts:"
 ls artifacts
 
+cat << "EOF" | tee ~/stop_auto_upgrades
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
+
 _run amixer set Master unmute
 _run amixer set Master 100
 _run amixer set Speaker 100
@@ -64,4 +71,6 @@ _run gsettings set org.gnome.desktop.screensaver lock-enabled false
 _run gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'nothing'
 _run gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type 'nothing'
 _run gsettings set org.gnome.desktop.session idle-delay 'uint32 0'
+_put ~/stop_auto_upgrades ~/20auto-upgrades
+_run sudo cp 20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
 


### PR DESCRIPTION
Some kernel version will be marked as security update that will force kernel to be updated during test period. Therefore, add related setting to avoid this.