### PR TITLE
workaround - fixed search patterns for jira summary

### DIFF
--- a/API/Jira/scenarios/pc/pc.py
+++ b/API/Jira/scenarios/pc/pc.py
@@ -110,7 +110,7 @@ class QaPcJira():
         """
         if tag:
             payload = {
-                'jql': 'project = {} AND summary ~ "{}" AND '
+                'jql': 'project = {} AND summary ~ "\\"{}\\"" AND '
                 'issuetype = Story order by created DESC'.format(
                     self.jira_api.jira_project['key'], tag
                 ),


### PR DESCRIPTION
Jira API failed to search jira issue with patterns with hyphen character this issue is not fixed yet in Jira API, so applied an workaround for this issue https://jira.atlassian.com/browse/JRACLOUD-75866