### PR TITLE
15_install_checkbox_on_agent: Install with pipx and remove dir afterwards

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/15_install_checkbox_on_agent
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/15_install_checkbox_on_agent
@@ -11,4 +11,5 @@ CHECKBOX_VERSION=$(_run $CHECKBOX_CLI_CMD --version)
 git clone --depth=1 https://github.com/canonical/hwcert-jenkins-tools.git > /dev/null
 git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
 hwcert-jenkins-tools/version-published/checkout_to_version.py ~/checkbox "$CHECKBOX_VERSION"
-(cd checkbox/checkbox-ng || return; sudo python3 setup.py install > /dev/null)
+pipx install --spec checkbox/checkbox-ng checkbox-ng
+sudo rm -rf checkbox


### PR DESCRIPTION
Installing with sudo caused problem with leftover files on agent. Consecutive job run will fail.
Using pipx works on cert lab and hot lab DUTs.

Test by generating the file locally and submit several times
`./testflinger_yaml_generator.py -c 202401-33392 --testplan audio-automated -o audio.yaml`

Jobs completed: 
https://testflinger.canonical.com/jobs/f63ce908-3f6f-4539-97dc-7d443ee5c6a1
https://testflinger.canonical.com/jobs/456c20b8-d8b4-4471-b544-ec7fe32f31bf