### PR TITLE
Edge stress test parser scripts

### DIFF
--- a/Tools/PC/c3-submission-helpers/README.md
+++ b/Tools/PC/c3-submission-helpers/README.md
@@ -6,7 +6,10 @@ submission files more friendly for humans.
 ## `parse-suspend-30-logs.py`
 
 This file helps break down the `com.canonical.certification__
-stress-tests_suspend-30-cycles-with-reboot-3-log-attach` to a more human friendly format.
+stress-tests_suspend-30-cycles-with-reboot-3-log-attach`
+to a more human friendly format.
+
+<!-- markdownlint-disable MD013 -->
 
 ```plaintext
 usage: parse-suspend-30-logs.py [-h] [-s] [-m] [-w] [-d WRITE_DIR] [-v]
@@ -49,6 +52,8 @@ options:
 
 ```
 
+<!-- markdownlint-enable MD013 -->
+
 Examples:
 
 - ```bash
@@ -77,7 +82,8 @@ Examples:
        -d path/to/output/dir
   ```
 
-  Specify a top level output directory of where the individual files will be written to.
+  Specify a top level output directory of
+  where the individual files will be written to.
   If this directory doesn't exist, the script will try to create it.
 
 ## `summarize_reboot_check_test.py`
@@ -123,4 +129,6 @@ python3 summarize_reboot_check_test.py /path/to/stress/test/submission.tar.xz
 
 ## Multiple input files
 
-Both scripts accept multiple input files. For now they just loop through them as if the command was called for each individual file.
+Both scripts accept multiple input files.
+For now they just loop through them as if
+the command was called for each individual file.

--- a/Tools/PC/c3-submission-helpers/README.md
+++ b/Tools/PC/c3-submission-helpers/README.md
@@ -6,38 +6,79 @@ submission files more friendly for humans.
 ## `parse-suspend-30-logs.py`
 
 This file helps break down the `com.canonical.certification__
-stress-tests_suspend-30-cycles-
-with-reboot-3-log-attach` to a more human friendly format.
+stress-tests_suspend-30-cycles-with-reboot-3-log-attach` to a more human friendly format.
+
+```plaintext
+usage: parse-suspend-30-logs.py [-h] [-s] [-m] [-w] [-d WRITE_DIR] [-v]
+                                [-nb NUM_BOOTS] [-ns NUM_SUSPENDS] [-t] [-c] [-iw]
+                                filenames [filenames ...]
+
+positional arguments:
+  filenames             The path to the stress test submission .tar files
+
+options:
+  -h, --help            show this help message and exit
+  -s, --no-summary      Don't print the summary file at the top (default: False)
+  -m, --no-meta         Don't write the metadata section when -w is specified. (The
+                        date/time/kernel section) (default: False)
+  -w, --write-individual-files
+                        If specified, the logs will be split up into individual
+                        files in a directory specified with -d (default: False)
+  -d WRITE_DIR, --directory WRITE_DIR
+                        The top level dir of where to write the individual logs.
+                        Inside this directory, subdirectories called {your original
+                        file name}-split will be created to contain the individual
+                        .txt files of each run (default: /your/current/directory)
+  -v, --verbose         Show line numbers of where the errors are in th input file
+                        (default: False)
+  -nb NUM_BOOTS, --num-boots NUM_BOOTS
+                        Set the expected number of boots in the input file.
+                        (default: 3)
+  -ns NUM_SUSPENDS, --num-suspends-per-boot NUM_SUSPENDS
+                        Set the expected number of runs in the input file. (default:
+                        30)
+  -t, --no-transform    Disables any form of error message tranformation except
+                        trimming whitespaces. By default, this script will attempt
+                        to remove timestamps and certain numbers to better group the
+                        error messages. This option disables this behavior.
+                        (default: False)
+  -c, --no-color        Disables all colors and styles (default: False)
+  -iw, --ignore-warnings
+                        Ignore warnings like checkbox's sleep_test_log_check.py
+                        (default: False)
+
+```
 
 Examples:
 
 - ```bash
-  python3 parse-suspend-30-logs.py -f path/to/submission-202408-12345.tar.xz
+  python3 parse-suspend-30-logs.py path/to/submission-202408-12345.tar.xz
   ```
 
-   will print out the **indexes** (starts at 1) of the runs with failures.
+  will print out error messages and the associated failed run/boot index
 
 - ```bash
   python3 parse-suspend-30-logs.py \
-      -f path/to/submission-202408-12345.tar.xz \
+      path/to/submission-202408-12345.tar.xz \
       -w
   ```
 
-   will print the output from above AND write the individual runs into its own
-   file.
+  will print the output from above AND write the individual runs into its own
+  file.
+
   - A new directory will be created in the current working directory named
-   "submission-202408-12345.tar.xz-split" and there will be
-   90 files inside named `1.txt, 2.txt, ..., 90.txt`
+    "submission-202408-12345.tar.xz-split" and there will be
+    90 files inside named `boot-1-suspend-1.txt, boot-1-suspend-2.txt, ..., boot-3-suspend-30.txt`
 
 - ```bash
    python3 parse-suspend-30-logs.py \
-       -f path/to/submission-202408-12345.tar.xz \
+       path/to/submission-202408-12345.tar.xz \
        -w \
        -d path/to/output/dir
-   ```
+  ```
 
-   Specify an output directory of where the 1.txt, 2.txt... will be saved to.
-   If this directory doesn't exist, the script will try to create it.
+  Specify a top level output directory of where the individual files will be written to.
+  If this directory doesn't exist, the script will try to create it.
 
 ## `summarize_reboot_check_test.py`
 
@@ -45,31 +86,33 @@ This script combines all the results from cold & warm boot tests that uses the
 new `reboot_check_test.py`.
 
 <!-- markdownlint-disable MD013 -->
+
 ```plaintext
-usage: summarize-reboot-check-test.py [-h] [-g] [-i] [-v]
-                                      [-n EXPECTED_N_RUNS] [--no-color]
-                                      filename
+usage: summarize-reboot-check-test.py [-h] [-g] [-i] [-v] [-n EXPECTED_N_RUNS]
+                                      [--no-color]
+                                      filenames [filenames ...]
 
 Parses the outputs of reboot_check_test.py from a C3 submission tar file
 
 positional arguments:
-  filename              path to the stress test tarball
+  filenames             Path to the stress test tarball. If multiple paths are
+                        specified, run the script for each of them
 
 options:
   -h, --help            show this help message and exit
-  -g, --group-by-err    Group run-indices by error messages. Similar messages
-                        might be shown twice
-  -i, --index-only      Only show the indices of the failed runs
-  -v, --verbose         Whether to print detailed messages
+  -g, --group-by-err    Group run-indices by error messages. Similar messages might
+                        be shown twice (default: False)
+  -i, --index-only      Only show the indices of the failed runs (default: False)
+  -v, --verbose         Whether to print detailed messages (default: False)
   -n EXPECTED_N_RUNS, --num-runs EXPECTED_N_RUNS
-                        Specify a value to show a warning when the number of
-                        boot files != the number of runs you expect.
-                        Default=30. Note that this number applies to both
-                        cold and warm boot since checkbox doesn't use a
-                        different number for CB/WB either.
-  --no-color            Removes all colors and styles
+                        Specify a value to show a warning when the number of boot
+                        files != the number of runs you expect. Note that this
+                        number applies to both cold and warm boot since checkbox
+                        doesn't use a different number for CB/WB. (default: 30)
+  --no-color            Removes all colors and styles (default: False)
 
 ```
+
 <!-- markdownlint-enable MD013 -->
 
 Example usage:
@@ -77,3 +120,7 @@ Example usage:
 ```bash
 python3 summarize_reboot_check_test.py /path/to/stress/test/submission.tar.xz
 ```
+
+## Multiple input files
+
+Both scripts accept multiple input files. For now they just loop through them as if the command was called for each individual file.

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -16,7 +16,7 @@ TEE = "├── "
 LAST = "└── "
 
 
-type FailType = Literal["Critical", "High", "Medium", "Low", "Other"]
+FailType = Literal["Critical", "High", "Medium", "Low", "Other"]
 
 
 SUMMARY_FILE_PATTERN = (
@@ -144,8 +144,8 @@ def parse_args() -> Input:
     return cast(Input, out)
 
 
-def line_is_summary_table(l: str) -> bool:
-    return l.replace(" ", "") == "Test|Pass|Fail|Abort|Warn|Skip|Info|"
+def line_is_summary_table(line: str) -> bool:
+    return line.replace(" ", "") == "Test|Pass|Fail|Abort|Warn|Skip|Info|"
 
 
 def open_log_file(
@@ -182,7 +182,10 @@ def open_log_file(
 
     summary_file = None
     if summary_file_name:
-        print(f"{C.low}[ INFO ]{C.end} Found this summary attachment:", f'"{summary_file_name}"')
+        print(
+            f"{C.low}[ INFO ]{C.end} Found this summary attachment:",
+            f'"{summary_file_name}"',
+        )
         summary_file = tarball.extractfile(summary_file_name)
         if summary_file is None:
             print(
@@ -231,9 +234,14 @@ def default_err_msg_transform(msg: str) -> str:
 
     known_prefixes = [
         "s3: Expected /sys/power/suspend_stats/total_hw_sleep to increase",
-        "s3: Expected /sys/kernel/debug/pmc_core/slp_s0_residency_usec to increase",
-        r"s3: Expected /sys/power/suspend_stats/last_hw_sleep "
-        + r"to be at least 70% of the last sleep cycle",
+        (
+            "s3: Expected /sys/kernel/debug/pmc_core/slp_s0_residency_usec "
+            + "to increase"
+        ),
+        (
+            r"s3: Expected /sys/power/suspend_stats/last_hw_sleep "
+            + r"to be at least 70% of the last sleep cycle"
+        ),
     ]
     for prefix in known_prefixes:
         if msg.startswith(prefix):
@@ -295,11 +303,15 @@ def print_by_err(
                     str(suspends),
                     width=50,
                 )
-                line1 = f"{SPACE} {SPACE} {TEE} Reboot {boot_i}: {wrapped_indices[0]}"
+                line1 = (
+                    f"{SPACE} {SPACE} {TEE} "
+                    + f"Reboot {boot_i}: {wrapped_indices[0]}"
+                )
                 print(line1)
                 for line in wrapped_indices[1:]:
                     print(
-                        f"{SPACE} {SPACE} {BRANCH}{' ' * len(f' Reboot {boot_i}: ')}",
+                        f"{SPACE} {SPACE} {BRANCH}"
+                        + f"{' ' * len(f' Reboot {boot_i}: ')}",
                         line,
                     )
 
@@ -320,7 +332,8 @@ def main():
 
     if args.no_transform:
         global transform_err_msg
-        transform_err_msg = lambda s: s.strip()
+        # idk why tox doesn't like this, this is super common
+        transform_err_msg = lambda s: s.strip()  # noqa: E731
 
     print(
         f"{C.medium}[ WARN ]{C.end} The summary file might not match",
@@ -440,7 +453,7 @@ def main():
                     os.mkdir(args.write_directory)
 
                 with open(
-                    f"{args.write_directory}/boot_{boot_i}_suspend_{suspend_i}.txt",
+                    f"{args.write_directory}/boot_{boot_i}_suspend_{suspend_i}.txt",  # noqa: E501
                     "w",
                 ) as f:
                     if curr_meta:
@@ -452,7 +465,7 @@ def main():
                         )
                         f.write(
                             "\n\n"
-                            f"{' END OF METADATA, BEGIN ORIGINAL OUTPUT  ':*^80}"
+                            f"{' END OF METADATA, BEGIN ORIGINAL FILE ':*^80}"
                             "\n\n"
                         )
                     else:

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -1,7 +1,8 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
+from collections import defaultdict
 import os
-from typing import Literal, TypedDict
+from typing import Literal, TypedDict, cast
 import re
 import argparse
 import tarfile
@@ -13,6 +14,16 @@ space = "    "
 branch = "│   "
 tee = "├── "
 last = "└── "
+bullet_point = "   -"
+
+
+FailType = Literal["Critical", "High", "Medium", "Low", "Other"]
+
+
+SUMMARY_FILE_PATTERN = (
+    r"test_output/com.canonical.certification__stress-tests"
+    r"_suspend-[0-9]+-cycles-with-reboot-[0-9]+-log-check"
+)
 
 
 class Input:
@@ -20,9 +31,11 @@ class Input:
     write_individual_files: bool
     write_directory: str
     verbose: bool
-    num_runs: int | None
+    num_suspends: int
+    num_boots: int
     inverse_find: bool
     no_summary: bool
+    no_meta: bool
 
 
 class C:  # color
@@ -33,6 +46,7 @@ class C:  # color
     other = "\033[96m"
     ok = "\033[92m"
     end = "\033[0m"
+    gray = "\033[90m"
 
 
 class Meta(TypedDict):
@@ -51,6 +65,14 @@ def parse_args() -> Input:
         "--no-summary",
         action="store_true",
         help="Don't print the summary file at the top",
+    )
+    p.add_argument(
+        "--no-meta",
+        action="store_true",
+        help=(
+            "Don't write the metadata section when -w is specified. ("
+            f"The {'/'.join(Meta.__annotations__.keys())} section)"
+        ),
     )
     p.add_argument(
         "filename",
@@ -86,10 +108,20 @@ def parse_args() -> Input:
         action="store_true",
     )
     p.add_argument(
-        "-n",
-        "--num-runs",
-        help="Set the expected number of runs in the input file. Default=90.",
-        dest="num_runs",
+        "-nb",
+        "--num-boots",
+        help="Set the expected number of boots in the input file. Default=3.",
+        dest="num_boots",
+        default=3,
+        required=False,
+        type=int,
+    )
+    p.add_argument(
+        "-ns",
+        "--num-suspends-per-boot",
+        help="Set the expected number of runs in the input file. Default=30.",
+        dest="num_suspends",
+        default=30,
         required=False,
         type=int,
     )
@@ -100,271 +132,280 @@ def parse_args() -> Input:
         action="store_true",
         default=False,
         help=(
-            "Find runs that do NOT have a failure instead of the opposite."
+            "Find runs that do NOT have a failure instead of the opposite. "
             "Useful if you encounter machines that fails almost every run."
         ),
     )
 
     out = p.parse_args()
     out.write_directory = out.write_directory or f"{out.filename}-split"
-    return out  # type:ignore
-
-
-FailType = Literal["Critical", "High", "Medium", "Low", "Other"]
-
-log_file_pattern = (
-    r"attachment_files/com.canonical.certification__"
-    r"stress-tests_suspend-[0-9]+-cycles-with-reboot-[0-9]+-log-attach"
-)
-summary_file_pattern = (
-    r"test_output/com.canonical.certification__stress-tests"
-    r"_suspend-[0-9]+-cycles-with-reboot-[0-9]+-log-check"
-)
+    return cast(Input, out)
 
 
 def open_log_file(
-    filename: str,
-) -> tuple[io.TextIOWrapper, io.TextIOWrapper | None]:
-    if not filename.endswith(".tar.xz"):
-        return (open(filename), None)
+    args: Input,
+) -> tuple[
+    dict[int, dict[int, io.TextIOWrapper]],  # {boot_i: {suspend_i: file_obj}}
+    io.TextIOWrapper | None,
+    dict[int, list[int]],
+]:
+    if not args.filename.endswith(".tar.xz"):
+        raise TypeError("File must be a tar file")
+
+    try:
+        tar = tarfile.open(args.filename)
+    except FileNotFoundError:
+        print(f"{C.critical}{args.filename} not found!{C.end}")
+        exit(1)
 
     summary_file_name = None
-    log_file_name = None
-    try:
-        possible_log_files = [
-            m.name
-            for m in tarfile.open(filename).getmembers()
-            if re.match(log_file_pattern, m.name) is not None
-        ]
-        possible_summary_files = [
-            m.name
-            for m in tarfile.open(filename).getmembers()
-            if re.match(summary_file_pattern, m.name) is not None
-        ]
-
-        if len(possible_log_files) == 0:
-            print(
-                f"No log files match {C.critical}`{log_file_pattern}`{C.end}"
-                f"was found in {filename}, exiting."
-            )
-            exit(1)
-        if len(possible_summary_files) == 0:
-            print(
-                "No attachment files matching",
-                f"{C.medium}`{summary_file_pattern}`{C.end}",
-                f"was found in {filename}. Ignoring",
-            )
-
-        if len(possible_log_files) > 1:
-            print(
-                f"Multiple log files found in {filename},",
-                f"assuming {possible_log_files[0]}",
-            )
-
-        log_file_name = possible_log_files[0]
-        summary_file_name = (
-            possible_summary_files[0]
-            if len(possible_summary_files) > 0
-            else None
+    possible_summary_files = [
+        m.name
+        for m in tar.getmembers()
+        if re.match(SUMMARY_FILE_PATTERN, m.name) is not None
+    ]
+    if len(possible_summary_files) == 0:
+        print(
+            "No attachment files matching",
+            f"{C.medium}`{SUMMARY_FILE_PATTERN}`{C.end}",
+            f"was found in {args.filename}. Ignoring",
         )
-        print("Parsing this file:", log_file_name)
+    summary_file_name = (
+        possible_summary_files[0] if len(possible_summary_files) > 0 else None
+    )
 
-        tar = tarfile.open(filename)
-        extracted_log = tar.extractfile(log_file_name)
-
-        if extracted_log is None:
+    summary_file = None
+    if summary_file_name:
+        print("Found this summary attachment:", f'"{summary_file_name}"')
+        summary_file = tar.extractfile(summary_file_name)
+        if summary_file is None:
             print(
-                f"Found {log_file_name} in {filename},",
-                "but it can't be extracted.",
+                f"Found {summary_file_name} in {args.filename},"
+                "but it can't be extracted, Ignoring",
                 file=sys.stderr,
             )
-            exit(1)
 
-        summary_file = None
-        if summary_file_name:
-            print("Found this summary attachment:", summary_file_name)
-            summary_file = tar.extractfile(summary_file_name)
-            if summary_file is None:
-                print(
-                    f"Found {summary_file_name} in {filename},"
-                    "but it can't be extracted, Ignoring",
-                    file=sys.stderr,
-                )
+    # 1 based indices
+    log_files = defaultdict(
+        defaultdict
+    )  # type: dict[int, dict[int,io.TextIOWrapper]]
+    missing_runs = defaultdict(list)  # type: dict[int, list[int]]
+    for boot_i in range(1, args.num_boots + 1):
+        for suspend_i in range(1, args.num_suspends + 1):
+            individual_file_name = (
+                "test_output/com.canonical.certification__stress-tests_"
+                + f"suspend_cycles_{suspend_i}_reboot{boot_i}"
+            )
+            try:
+                extracted = tar.extractfile(individual_file_name)
+                assert extracted, f"Failed to extract {individual_file_name}"
+                log_files[boot_i][suspend_i] = io.TextIOWrapper(extracted)
+            except KeyError:  # from extract
+                missing_runs[boot_i].append(suspend_i)
 
-        log_file = io.TextIOWrapper(extracted_log)
-
-        return (
-            log_file,
-            io.TextIOWrapper(summary_file) if summary_file else None,
-        )
-    except KeyError:
-        print(
-            f'{C.critical}"{log_file_name}" doesn\'t exist in the tarball',
-            f'"{filename}"{C.end}',
-            file=sys.stderr,
-        )
-        print(
-            "If the log file is under a different name,",
-            f"try manually extracting {filename} and pass in",
-            "path/to/the/log/file with the -f flag.",
-        )
-        exit(1)
+    return (
+        log_files,
+        summary_file and io.TextIOWrapper(summary_file),
+        missing_runs,
+    )
 
 
 def main():
-    SECTION_BEGIN = "= Test Results ="  # noqa: N806
-
     args = parse_args()
-    EXPECTED_NUM_RESULTS = args.num_runs or 90  # noqa: N806
-    print(f"{C.ok}Expecting {EXPECTED_NUM_RESULTS} results{C.end}")
+    expected_num_results = args.num_boots * args.num_suspends  # noqa: N806
+
+    print(
+        f"Expecting ({args.num_boots} boots * "
+        f"{args.num_suspends} suspends per boot) = "
+        f"{expected_num_results} results"
+    )
 
     if args.write_individual_files:
         print(f'Individual results will be in "{args.write_directory}"')
 
-    log_file, summary_file = open_log_file(args.filename)
+    log_files, summary_file, missing_runs = open_log_file(args)
 
-    if args.filename.endswith(".tar.xz"):
-        if not args.no_summary:
-            if summary_file:
+    if not args.no_summary:
+        if summary_file:
+            print(f"\n{C.gray}{' Begin Summary Attachment ':-^80}{C.end}\n")
 
-                print(f"\n{' Begin Summary Attachment ':-^80}\n")
-                for line in summary_file.readlines():
-                    clean_line = line.strip()
-                    if clean_line != "":
-                        print(clean_line)
-                summary_file.close()
+            for line in summary_file.readlines():
+                clean_line = line.strip()
+                if clean_line != "":
+                    print(clean_line)
+            summary_file.close()
 
-                print(f"\n{' End of Summary ':-^80}")
-            else:
-                print(
-                    "No suspend-30-cycles-with-reboot-3-log-check attachment",
-                    "was found in the tarball",
-                )
+            print(f"\n{C.gray}{' End of Summary ':-^80}{C.end}\n")
+        else:
+            print(
+                "No suspend-30-cycles-with-reboot-3-log-check attachment",
+                "was found in the tarball",
+            )
 
-    with log_file as file:
-        lines = file.readlines()
-        test_results: list[list[str]] = []
-        meta: list[Meta] = []
-        failed_runs_by_type: dict[FailType, list[int]] = {
-            "Critical": [],
-            "High": [],
-            "Medium": [],
-            "Low": [],
-            "Other": [],
-        }
+    failed_runs_by_type: dict[FailType, dict[int, list[int]]] = {
+        "Critical": {},
+        "High": {},
+        "Medium": {},
+        "Low": {},
+        "Other": {},
+    }
+    for boot_i in log_files:
+        for suspend_i in log_files[boot_i]:
+            log_file = log_files[boot_i][suspend_i]
+            curr_meta = None  # type: Meta | None
 
-        i = 0
-        while i < len(lines) and SECTION_BEGIN not in lines[i]:
-            i += 1  # scroll to the first section
-
-        while i < len(lines):
-            line = lines[i]
-
-            if SECTION_BEGIN not in line:
-                continue
-
-            i += 1
-            curr_result_lines: list[str] = []
-            curr_meta: Meta = {"date": "", "time": "", "kernel": ""}
-
-            while i < len(lines) and SECTION_BEGIN not in lines[i]:
-                curr_line = lines[i].strip().strip("\n")
-
-                if curr_line != "":
-                    curr_result_lines.append(curr_line)
-
-                if curr_line.startswith("This test run on"):
+            for line in log_file:
+                if line.startswith("This test run on"):
                     # Example:
                     # This test run on 13/08/24 at
                     # 01:10:22 on host Linux ubuntu 6.5.0-1027-oem
                     regex = r"This test run on (.*) at (.*) on host (.*)"
-                    match_output = re.match(regex, curr_line)
+                    match_output = re.match(regex, line)
                     if match_output:
-                        curr_meta["date"] = match_output.group(1)
-                        curr_meta["time"] = match_output.group(2)
-                        curr_meta["kernel"] = match_output.group(3)
+                        curr_meta = Meta(
+                            date=match_output.group(1),
+                            time=match_output.group(2),
+                            kernel=match_output.group(3),
+                        )
+                    continue
 
                 for fail_type in "Critical", "High", "Medium", "Low", "Other":
-                    if curr_line.startswith(f"{fail_type} failures: "):
-                        fail_count = curr_line.split(": ")[1]
+                    if line.startswith(f"{fail_type} failures: "):
+                        fail_count = line.split(":")[1].strip()
                         if fail_count == "NONE":
                             continue
-                        if args.verbose:
-                            t = fail_type.lower()
-                            print(
-                                f"Line {i}, run {len(test_results) + 1} has "
-                                f"{getattr(C, t)}{t}{C.end} "
-                                f"failures: {fail_count}"
-                            )
 
-                        failed_runs_by_type[fail_type].append(
-                            len(test_results) + 1
-                        )
-                i += 1
+                        if boot_i in failed_runs_by_type[fail_type]:
+                            failed_runs_by_type[fail_type][boot_i].append(
+                                suspend_i
+                            )
+                        else:
+                            failed_runs_by_type[fail_type][boot_i] = [
+                                suspend_i
+                            ]
 
             if args.write_individual_files:
+                print(
+                    f"Writing boot_{boot_i}_suspend_{suspend_i}.txt...",
+                    end="\r",
+                )
                 if not os.path.exists(args.write_directory):
                     os.mkdir(args.write_directory)
+
                 with open(
-                    f"{args.write_directory}/{len(test_results) + 1}.txt", "w"
+                    f"{args.write_directory}/boot_{boot_i}_suspend_{suspend_i}.txt",
+                    "w",
                 ) as f:
-                    f.write(f"{' BEGIN METADATA  ':*^80}\n\n")
-                    f.write(
-                        "\n".join(f"{k}: {v}" for k, v in curr_meta.items())
-                    )
-                    f.write(
-                        "\n\n"
-                        f"{' END OF METADATA, BEGIN ORIGINAL OUTPUT  ':*^80}"
-                        "\n\n"
-                    )
-                    f.write("\n".join(curr_result_lines))
-
-            test_results.append(curr_result_lines)
-            meta.append(curr_meta)
-
-        n_results = len(test_results)
-        print(
-            f"\nTotal results = {n_results}"
-            + (
-                f" {C.ok}COUNT OK!{C.end}"
-                if n_results == EXPECTED_NUM_RESULTS
-                else (
-                    f", {C.critical}but {EXPECTED_NUM_RESULTS} "
-                    f"was expected{C.end}"
-                )
-            )
-        )
-
-        for fail_type, runs in failed_runs_by_type.items():
-            if len(runs) != 0:
-                if args.inverse_find:
-                    runs_without_failures = list(
-                        set(range(1, n_results + 1)).difference(runs)
-                    )
-                    print(
-                        f"Runs without {getattr(C, fail_type.lower())}"
-                        f"{fail_type}{C.end} failures:"
-                    )
-                    print(
-                        space
-                        + (f"\n{space}").join(
-                            textwrap.wrap(str(runs_without_failures))
+                    if curr_meta:
+                        f.write(f"{' BEGIN METADATA  ':*^80}\n\n")
+                        f.write(
+                            "\n".join(
+                                f"{k}: {v}" for k, v in curr_meta.items()
+                            )
                         )
-                    )
-                    print(
-                        f"{space}- Success rate:",
-                        f"{len(runs_without_failures)}/{n_results}",
-                    )
-                else:
-                    print(
-                        f"Runs with {getattr(C, fail_type.lower())}"
-                        f"{fail_type}{C.end} failures:"
-                    )
-                    print(
-                        space + (f"\n{space}").join(textwrap.wrap(str(runs)))
-                    )
-                    print(f"{space}- Fail rate: {len(runs)}/{n_results}")
+                        f.write(
+                            "\n\n"
+                            f"{' END OF METADATA, BEGIN ORIGINAL OUTPUT  ':*^80}"
+                            "\n\n"
+                        )
+                    else:
+                        print(
+                            f"{C.high}[ WARN ]{C.end} No meta data was found",
+                            f"for boot {boot_i} suspend {suspend_i}",
+                        )
+                    log_file.seek(0)
+                    f.write(log_file.read())
+
+            log_file.close()
+
+    # done collecting, pretty print results
+    if sum(map(len, missing_runs.values())) == 0:
+        print(
+            f"{C.ok}[ OK ]{C.end} Found all {expected_num_results}",
+            "expected log files!",
+        )
+    else:
+        print(
+            f"{C.critical}These log files are missing;",
+            f"DUT might have crashed during these jobs!{C.end}",
+        )
+        for boot_i, suspend_indicies in missing_runs.items():
+            print(f"- Reboot {boot_i}, suspend {str(suspend_indicies)}")
+    if sum(map(len, failed_runs_by_type.values())) == 0:
+        print(
+            f"{C.ok}No failures across {args.num_boots} boots "
+            f"and {args.num_suspends} suspends!{C.end}"
+        )
+        return
+
+    print()
+    print(C.gray + "=" * 80 + C.end)
+
+    for fail_type, runs in failed_runs_by_type.items():
+        fail_type = fail_type.lower()
+        if len(runs) == 0:
+            continue
+
+        total_fails_of_this_type = sum(map(len, runs.values()))
+
+        if args.inverse_find:
+            print(
+                f"\nRuns without {getattr(C, fail_type)}{fail_type}{C.end} failures:"
+            )
+        else:
+            print(
+                f"\nFound {total_fails_of_this_type} run(s) with",
+                f"{getattr(C, fail_type)}{fail_type}{C.end} failures:",
+            )
+
+        for boot_i in range(1, args.num_boots + 1):
+            branch_text = last if boot_i == args.num_boots else tee
+            if boot_i not in runs:
+                print(f"{space} {branch_text} Reboot {boot_i}: No failures!")
+                continue
+
+            branch_text = last if boot_i == args.num_boots else branch
+            if args.inverse_find:
+                indices_to_print = list(
+                    set(range(1, args.num_suspends + 1))
+                    - set(missing_runs[boot_i])
+                    - set(runs[boot_i])
+                )
+            else:
+                indices_to_print = runs[boot_i]
+
+            wrapped_suspend_indices = textwrap.wrap(
+                str(indices_to_print),
+                width=50,
+            )
+            line1 = (
+                f"{space} {tee} Reboot {boot_i}: {wrapped_suspend_indices[0]}"
+            )
+            print(line1)
+            for line in wrapped_suspend_indices[1:]:
+                print(
+                    f"{space} {branch}{' ' * len(f' Reboot {boot_i}: ')}", line
+                )
+
+            if args.inverse_find:
+                print(
+                    space,
+                    branch_text,
+                    f"Success rate: {len(indices_to_print)}/{args.num_suspends}",
+                )
+            else:
+                print(
+                    space,
+                    branch_text,
+                    f"Fail rate: {len(indices_to_print)}/{args.num_suspends}",
+                )
 
 
 if __name__ == "__main__":
+    print(
+        f"{C.medium}The summary file might not match the number of failures",
+        "found by this script.",
+        "Please double check as the original test case did some filtering.",
+        C.end,
+    )
     main()

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -424,7 +424,7 @@ def print_summary_for_1_submission(
     args: Input, filename: str, transform_err_msg: Callable[[str], str]
 ) -> None:
     expected_num_results = args.num_boots * args.num_suspends  # noqa: N806
-    write_dir = f"{args.write_dir}/{filename.replace("/", '-')}-split"
+    write_dir = f"{args.write_dir}/{filename.replace('/', '-')}-split"
 
     if args.write_individual_files:
         print(

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -10,11 +10,10 @@ import io
 import sys
 import textwrap
 
-space = "    "
-branch = "│   "
-tee = "├── "
-last = "└── "
-bullet_point = "   -"
+SPACE = "    "
+BRANCH = "│   "
+TEE = "├── "
+LAST = "└── "
 
 
 FailType = Literal["Critical", "High", "Medium", "Low", "Other"]
@@ -359,12 +358,12 @@ def main():
             )
 
         for boot_i in range(1, args.num_boots + 1):
-            branch_text = last if boot_i == args.num_boots else tee
+            branch_text = LAST if boot_i == args.num_boots else TEE
             if boot_i not in runs:
-                print(f"{space} {branch_text} Reboot {boot_i}: No failures!")
+                print(f"{SPACE} {branch_text} Reboot {boot_i}: No failures!")
                 continue
 
-            branch_text = last if boot_i == args.num_boots else branch
+            branch_text = LAST if boot_i == args.num_boots else BRANCH
             if args.inverse_find:
                 indices_to_print = list(
                     set(range(1, args.num_suspends + 1))
@@ -379,23 +378,23 @@ def main():
                 width=50,
             )
             line1 = (
-                f"{space} {tee} Reboot {boot_i}: {wrapped_suspend_indices[0]}"
+                f"{SPACE} {TEE} Reboot {boot_i}: {wrapped_suspend_indices[0]}"
             )
             print(line1)
             for line in wrapped_suspend_indices[1:]:
                 print(
-                    f"{space} {branch}{' ' * len(f' Reboot {boot_i}: ')}", line
+                    f"{SPACE} {BRANCH}{' ' * len(f' Reboot {boot_i}: ')}", line
                 )
 
             if args.inverse_find:
                 print(
-                    space,
+                    SPACE,
                     branch_text,
                     f"Success rate: {len(indices_to_print)}/{args.num_suspends}",
                 )
             else:
                 print(
-                    space,
+                    SPACE,
                     branch_text,
                     f"Fail rate: {len(indices_to_print)}/{args.num_suspends}",
                 )

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -450,8 +450,7 @@ def main():
     if args.write_individual_files:
         print(
             C.low("[ INFO ]"),
-            f"Individual results will be in",
-            f'"{args.write_dir}"',
+            f'Individual results will be in "{args.write_dir}"',
         )
         if not os.path.exists(args.write_dir):
             os.mkdir(args.write_dir)

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -182,7 +182,7 @@ def open_log_file(
 
     summary_file = None
     if summary_file_name:
-        print("Found this summary attachment:", f'"{summary_file_name}"')
+        print(f"{C.low}[ INFO ]{C.end} Found this summary attachment:", f'"{summary_file_name}"')
         summary_file = tarball.extractfile(summary_file_name)
         if summary_file is None:
             print(
@@ -216,7 +216,7 @@ def open_log_file(
     )
 
 
-def trim_time_and_counts(msg: str) -> str:
+def default_err_msg_transform(msg: str) -> str:
     # some known error message transforms to help group them together
     # this is disabled with --no-transform flag
     kernel_msg_prefix_pattern = (
@@ -238,6 +238,10 @@ def trim_time_and_counts(msg: str) -> str:
     for prefix in known_prefixes:
         if msg.startswith(prefix):
             return prefix
+
+    known_patterns = {r"slept for (.*) seconds,": "slept"}
+    for pattern, replacement in known_patterns.items():
+        msg = re.sub(pattern, replacement, msg)
 
     return msg
 
@@ -305,9 +309,10 @@ def print_by_err(
                     branch_text,
                     f"Fail rate: {fail_rate_text}",
                 )
+        print()  # new line between critical, high ...
 
 
-transform_err_msg = trim_time_and_counts
+transform_err_msg = default_err_msg_transform
 
 
 def main():
@@ -318,23 +323,28 @@ def main():
         transform_err_msg = lambda s: s.strip()
 
     print(
-        f"{C.medium}[ WARN ] The summary file might not match",
+        f"{C.medium}[ WARN ]{C.end} The summary file might not match",
         "the number of failures found by this script.",
-        "Please double check since the original test case did some filtering",
+    )
+    print(
+        f"{C.medium}[ WARN ]{C.end} Please double check since",
+        "the original test case did some filtering",
         "and may consider some failures to be not worth reporting",
-        C.end,
     )
 
     expected_num_results = args.num_boots * args.num_suspends  # noqa: N806
 
     print(
-        f"Expecting ({args.num_boots} boots * "
+        f"{C.low}[ INFO ]{C.end} Expecting ({args.num_boots} boots * "
         f"{args.num_suspends} suspends per boot) = "
         f"{expected_num_results} results"
     )
 
     if args.write_individual_files:
-        print(f'Individual results will be in "{args.write_directory}"')
+        print(
+            f"{C.low}[ INFO ]{C.end} Individual results will be in",
+            f'"{args.write_directory}"',
+        )
 
     log_files, summary_file, missing_runs = open_log_file(args)
 
@@ -460,12 +470,12 @@ def main():
 
     if n_missing_runs == 0:
         print(
-            f"{C.ok}[ OK ]{C.end} Found all {expected_num_results}",
+            f"{C.ok}[  OK  ]{C.end} Found all {expected_num_results}",
             "expected log files!",
         )
         if n_failed_runs == 0:
             print(
-                f"{C.ok}[ OK ]{C.end}",
+                f"{C.ok}[  OK  ]{C.end}",
                 f"No failures across {args.num_boots} boots",
                 f"and {args.num_suspends} suspends!",
             )

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -9,7 +9,6 @@ import tarfile
 import textwrap
 from collections import defaultdict
 from typing import Literal, TypedDict, cast
-from rich.console import Console
 
 SPACE = "    "
 BRANCH = "│   "
@@ -64,11 +63,13 @@ class Meta(TypedDict):
 def parse_args() -> Input:
     p = argparse.ArgumentParser()
     p.add_argument(
+        "-s",
         "--no-summary",
         action="store_true",
         help="Don't print the summary file at the top",
     )
     p.add_argument(
+        "-m",
         "--no-meta",
         action="store_true",
         help=(
@@ -348,12 +349,15 @@ def main():
         "Low": {},
         "Other": {},
     }
+
     for boot_i in log_files:
         for suspend_i in log_files[boot_i]:
             log_file = log_files[boot_i][suspend_i]
+            log_file_lines = log_file.readlines()
+            log_file.close()
+
             curr_meta = None  # type: Meta | None
 
-            log_file_lines = log_file.readlines()
             for i, line in enumerate(log_file_lines):
                 if line.startswith("This test run on"):
                     # Example:
@@ -441,10 +445,9 @@ def main():
                             f"{C.high}[ WARN ]{C.end} No meta data was found",
                             f"for boot {boot_i} suspend {suspend_i}",
                         )
-                    log_file.seek(0)
-                    f.write(log_file.read())
 
-            log_file.close()
+                    for line in log_file_lines:
+                        f.write(line)
 
     # done collecting, pretty print results
     n_missing_runs = sum(map(len, missing_runs.values()))

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -105,7 +105,9 @@ FAIL_TYPES = ("Critical", "High", "Medium", "Low", "Other")
 
 
 def parse_args() -> Input:
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     p.add_argument(
         "-s",
         "--no-summary",
@@ -124,7 +126,7 @@ def parse_args() -> Input:
     p.add_argument(
         "filenames",
         nargs="+",
-        help="The path to the suspend logs or the stress test submission .tar",
+        help="The path to the stress test submission .tar files",
     )
     p.add_argument(
         "-w",
@@ -139,13 +141,13 @@ def parse_args() -> Input:
         "-d",
         "--directory",
         dest="write_dir",
-        default="",
+        default=os.getcwd(),
         required=False,
         help=(
-            "Where to write the individual logs. "
-            "If not specified and the -w flag is true, "
-            "it will create a new local directory called "
-            "{your original file name}-split."
+            "The top level dir of where to write the individual logs. "
+            "Inside this directory, subdirectories called "
+            "{your original file name}-split will be created to contain the "
+            "individual .txt files of each run"
         ),
     )
     p.add_argument(
@@ -158,7 +160,7 @@ def parse_args() -> Input:
     p.add_argument(
         "-nb",
         "--num-boots",
-        help="Set the expected number of boots in the input file. Default=3.",
+        help="Set the expected number of boots in the input file.",
         dest="num_boots",
         default=3,
         required=False,
@@ -167,7 +169,7 @@ def parse_args() -> Input:
     p.add_argument(
         "-ns",
         "--num-suspends-per-boot",
-        help="Set the expected number of runs in the input file. Default=30.",
+        help="Set the expected number of runs in the input file.",
         dest="num_suspends",
         default=30,
         required=False,

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -512,7 +512,8 @@ def print_summary_for_1_submission(
                             error_msg_i += 1
 
                             if args.ignore_warnings and "Warning:" in msg:
-                                # literally how the original test case filters warnings
+                                # literally how the original test case
+                                # filters warnings
                                 continue
                             failed_runs[fail_type][boot_i][suspend_i].add(msg)
 

--- a/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
+++ b/Tools/PC/c3-submission-helpers/parse-suspend-30-logs.py
@@ -1,14 +1,14 @@
 #! /usr/bin/env python3
 
-from collections import defaultdict
-import os
-from typing import Literal, TypedDict, cast
-import re
 import argparse
-import tarfile
 import io
+import os
+import re
 import sys
+import tarfile
 import textwrap
+from collections import defaultdict
+from typing import Literal, TypedDict, cast
 
 SPACE = "    "
 BRANCH = "│   "
@@ -402,8 +402,8 @@ def main():
 
 if __name__ == "__main__":
     print(
-        f"{C.medium}The summary file might not match the number of failures",
-        "found by this script.",
+        f"{C.medium}The summary file might not match",
+        "the number of failures found by this script.",
         "Please double check as the original test case did some filtering.",
         C.end,
     )

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -10,13 +10,13 @@ to report accurately
 
 import abc
 import argparse
-from collections import defaultdict, Counter
-from typing import Callable, Literal, Optional
 import io
 import itertools
-import tarfile
 import re
+import tarfile
 import textwrap
+from collections import Counter, defaultdict
+from typing import Callable, Literal, Optional
 
 SPACE = "    "
 BRANCH = "│   "
@@ -388,7 +388,10 @@ class FwtsPrinter(TestResultPrinter):
         "- card",  # the drm list bullet
         "Checking if DUT has reached",
         "Graphical target was reached!",
+        "Starting reboot checks",
+        "Finished reboot checks"
     ]
+
     exclude_suffixes = [
         "is connected to display!",
         "connected",
@@ -521,9 +524,9 @@ class DeviceComparisonPrinter(TestResultPrinter):
 
                         actual_diff = max(diff, reverse_diff, key=len)
                         diff_name = (
-                            "Extra device"
+                            "Extra"
                             if len(diff) > len(reverse_diff)
-                            else "Missing device"
+                            else "Missing"
                         )
 
                         if run_index not in res[device_type]:
@@ -650,6 +653,7 @@ def main():
     reader = SubmissionTarReader(args.filename)
 
     if args.no_color:
+        # if no color, just replace all the escape sequences with empty str
         for prop in dir(Color):
             if prop.startswith("__") and type(getattr(Color, prop)) is not str:
                 continue

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -375,7 +375,7 @@ class FwtsPrinter(TestResultPrinter):
 
     # this is kinda dumb but fwts output is mixed with
     # output from other tests
-    # ! these strings should not start with spaces
+    # !! these strings should not start with spaces
     exclude_prefixes = [
         "[ OK ]",
         "Comparing devices",
@@ -389,7 +389,9 @@ class FwtsPrinter(TestResultPrinter):
         "Checking if DUT has reached",
         "Graphical target was reached!",
         "Starting reboot checks",
-        "Finished reboot checks"
+        "Finished reboot checks",
+        "Found GL_RENDERER",
+        "Checking hardware renderer",
     ]
 
     exclude_suffixes = [
@@ -574,6 +576,11 @@ class RendererCheckPrinter(TestResultPrinter):
         graphical_target_fail_prefix = (
             "[ ERR ] systemd's graphical.target was not reached"
         )
+        software_rendering_prefix = "[ ERR ] Software rendering detected"
+        # this generic prefix works becuase we immediately stop the test
+        # once glmark2 errors out. If there're multiple glmark2 errors before 
+        # end of test, change this accordingly
+        glmark2_err_prefix = "[ ERR ] glmark2"
 
         for boot_type in ("cold", "warm"):
             res = (
@@ -592,6 +599,10 @@ class RendererCheckPrinter(TestResultPrinter):
                             res["Graphical target not reached"][run_index] = [
                                 line
                             ]
+                        elif line.startswith(software_rendering_prefix):
+                            res["Found software rendering"][run_index] = [line]
+                        elif line.startswith(glmark2_err_prefix):
+                            res["glmark2"][run_index] = [line]
 
 
 def parse_args() -> Input:

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -77,9 +77,6 @@ class Color:
         return f"\033[1m{s}\033[0m"
 
 
-C = Color()
-
-
 class Log:
     @staticmethod
     def ok(*args: str):
@@ -672,7 +669,8 @@ class RendererCheckPrinter(TestResultPrinter):
 def parse_args() -> Input:
     p = argparse.ArgumentParser(
         description="Parses the outputs of reboot_check_test.py "
-        "from a C3 submission tar file"
+        "from a C3 submission tar file",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument(
         "filenames",
@@ -711,9 +709,9 @@ def parse_args() -> Input:
         dest="expected_n_runs",
         help=(
             "Specify a value to show a warning when the number of boot files "
-            "!= the number of runs you expect. Default=30. "
+            "!= the number of runs you expect. "
             "Note that this number applies to both cold and warm boot "
-            "since checkbox doesn't use a different number for CB/WB either."
+            "since checkbox doesn't use a different number for CB/WB. "
         ),
         type=int,
         default=30,
@@ -729,7 +727,8 @@ def parse_args() -> Input:
 def main():
     args = parse_args()
 
-    C.no_color = args.no_color
+    global C
+    C = Color(no_color=args.no_color)
 
     for filename in args.filenames:
         reader = SubmissionTarReader(filename)

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -433,7 +433,7 @@ class FwtsPrinter(TestResultPrinter):
             prefix_pattern = (
                 r"(CRITICAL|HIGH|MEDIUM|LOW|OTHER) Kernel message:"
             )
-            timestamp_pattern = r"\[ +[0-9]+.[0-9]+\]"  # example [   3.415050]
+            timestamp_pattern = r"\[ *[0-9]+.[0-9]+\]"  # example [   3.415050]
             return re.sub(
                 prefix_pattern, "", re.sub(timestamp_pattern, "", msg)
             ).strip()

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -743,8 +743,6 @@ def main():
                 f"Expected {args.expected_n_runs} runs,",
                 f"but got {reader.boot_count}",
             )
-        else:
-            Log.ok("")
 
         printer_classes: dict[TestType, type[TestResultPrinter]] = {
             klass.name: klass

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -695,7 +695,8 @@ def main():
     for filename in args.filenames:
         reader = SubmissionTarReader(filename)
         print(
-            "Checking if the tar file has the expected number of runs...",
+            "Checking if the tar file has all",
+            f"{args.expected_n_runs} expected runs...",
             end=" ",
         )
         if reader.boot_count != args.expected_n_runs:
@@ -704,7 +705,7 @@ def main():
                 f"but got {reader.boot_count}",
             )
         else:
-            Log.ok(f"Found the expected {args.expected_n_runs} runs.")
+            Log.ok("")
 
         printer_classes = {
             klass.name: klass
@@ -718,7 +719,8 @@ def main():
 
         for test in printer_classes:
             printer = printer_classes[test](reader, args.expected_n_runs)
-            print(f"\n{f' {printer.name.capitalize()} failures ':-^80}\n")
+            print(f"\n{f' {printer.name.capitalize()} failures ':-^80}")
+            print(f"{Color.gray}In file {filename}{Color.end}\n")
 
             if (len(printer.cold_results) + len(printer.warm_results)) == 0:
                 Log.ok(f"No {printer.name} failures")
@@ -730,8 +732,6 @@ def main():
                 printer.print_by_index()
             else:
                 printer.print_by_err()
-
-        print(f"\n{Color.gray}{f' End of {filename} ':=^80}{Color.end}\n")
 
 
 if __name__ == "__main__":

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -57,16 +57,14 @@ class Log:
         print(f"{Color.critical}[ ERR ]{Color.end}", *args)
 
 
-type RunIndexToMessageMap = dict[int, list[str]]
-type GroupedResultByIndex = dict[
+RunIndexToMessageMap = dict[int, list[str]]
+GroupedResultByIndex = dict[
     str, RunIndexToMessageMap
 ]  # key is fail type (for fwts it's critical, high, medium, low
 # for device cmp it's lsusb, lspci, iw)
 # value is index to actual message map
-type BootType = Literal["warm", "cold"]
-type TestType = Literal[
-    "fwts", "device comparison", "renderer", "service check"
-]
+BootType = Literal["warm", "cold"]
+TestType = Literal["fwts", "device comparison", "renderer", "service check"]
 
 
 class SubmissionTarReader:
@@ -224,11 +222,11 @@ class TestResultPrinter(abc.ABC):
         err_msg_transform: Optional[Callable[[str], str]] = None,
     ):
         """
-        Prints the results from 
+        Prints the results from
 
         :param title_transform: _description_, defaults to None
         :param err_msg_transform: _description_, defaults to None
-        """        
+        """
         fail_types = max(self.cold_results, self.warm_results, key=len).keys()
 
         for fail_type in fail_types:

--- a/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
+++ b/Tools/PC/c3-submission-helpers/summarize-reboot-check-test.py
@@ -527,7 +527,7 @@ class FwtsPrinter(TestResultPrinter):
 
                             # remove the "(x 2)" counter
                             results[fail_type][run_index].append(
-                                re.sub(r"\(x \d+\)", "", msg).strip()
+                                re.sub(r"\(x \d+\)$", "", msg).strip()
                             )
 
 


### PR DESCRIPTION
basically the newest (not very tested) versions of the helper scripts in https://github.com/canonical/oem-qa-tools/tree/main/Tools/PC/c3-submission-helpers

If you encounter issues with the scripts on the main branch (for example if they are not filtering certain outputs correctly), try these ones

requires python 3.10+, no dependencies

(if you are not seeing bold error messages, it might be because your terminal font can't be bold-ed.)