### PR TITLE
Update github runners to at least 22.04 and remove <py3.10 testing environments

### DIFF
--- a/.github/workflows/markdown_and_shellcheck.yml
+++ b/.github/workflows/markdown_and_shellcheck.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-jira-card-creator.yml
+++ b/.github/workflows/test-jira-card-creator.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test-transfer-hw-to-cert.yml
+++ b/.github/workflows/test-transfer-hw-to-cert.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: ["3.9", "3.10"]
+        os: [ubuntu-22.04, ubuntu-24.04]
+        python-version: ["3.10", "3.12"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     strategy:
       matrix:
-        python: ["3.6", "3.8", "3.10"]
-    runs-on: ubuntu-20.04
+        python: ["3.8", "3.10", "3.12"]
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python: ["3.8", "3.10", "3.12"]
+        python: ["3.10", "3.12"]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,54 +1,11 @@
 [tox]
-envlist = py35,py36,py38,py310
+envlist = py310,py312
 skip_missing_interpreters = true
 skipsdist=True
 
 [testenv]
 allowlist_externals = rm
 commands = flake8 .
-
-[testenv:py35]
-deps =
-    flake8
-    natsort == 4.0.3
-    requests == 2.9.1
-    urwid == 1.3.1
-    Jinja2 == 2.8
-    MarkupSafe == 0.23
-    XlsxWriter == 0.7.3
-    tqdm == 4.19.5
-    pyparsing == 2.0.3
-    distro == 1.0.1
-    PyYAML == 3.11
-
-[testenv:py36]
-deps =
-    flake8
-    natsort == 4.0.3
-    requests == 2.18.4
-    urwid == 2.0.1
-    Jinja2 == 2.10
-    MarkupSafe == 1.1.0
-    XlsxWriter == 0.9.6
-    tqdm == 4.19.5
-    pyparsing == 2.2.0
-    distro == 1.0.1
-    PyYAML == 3.12
-
-[testenv:py38]
-deps =
-    flake8
-    pep8-naming
-    natsort == 7.0.1
-    requests == 2.22.0
-    urwid == 2.0.1
-    Jinja2 == 2.10.1
-    MarkupSafe == 1.1.0
-    XlsxWriter == 1.1.2
-    tqdm == 4.30.0
-    pyparsing == 2.4.6
-    distro == 1.4.0
-    PyYAML == 5.3.1
 
 [testenv:py310]
 deps =
@@ -64,3 +21,19 @@ deps =
     pyparsing == 2.4.7
     distro == 1.7.0
     PyYAML == 6.0.1
+
+[testenv:py312]
+deps =
+    flake8
+    pep8-naming
+    natsort == 8.4.0
+    requests == 2.32.3
+    urwid == 2.6.16
+    Jinja2 == 3.1.6
+    MarkupSafe == 3.0.2
+    XlsxWriter == 3.2.3
+    tqdm == 4.67.1
+    pyparsing == 3.2.3
+    distro == 1.9.0
+    PyYAML == 6.0.2
+


### PR DESCRIPTION
20.04 runners are getting deprecated by github. This PR updates all the github runner yamls to start using >=22.04 runners and testing python code on >=py3.10. 