### PR TITLE
Drop 2004 in GitHub action

### DIFF
--- a/.github/workflows/markdown_and_shellcheck.yml
+++ b/.github/workflows/markdown_and_shellcheck.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/markdown_and_shellcheck.yml
+++ b/.github/workflows/markdown_and_shellcheck.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-20.04, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run markdownlint-cli2
         uses: DavidAnson/markdownlint-cli2-action@v10
         with:

--- a/.github/workflows/test-jira-card-creator.yml
+++ b/.github/workflows/test-jira-card-creator.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         python: ["3.6", "3.8", "3.10"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python: ["3.6", "3.8", "3.10"]
+        python: ["3.7", "3.8", "3.10"]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Github action has dropped ubuntu 20.04. Therefore, this PR is going to migrate the test related to 20.04 to 22.04 and 24.04.