### PR TITLE
fix: update deprecated daemon section

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/launcher_config/main.conf
+++ b/Tools/PC/testflinger_yaml_generator/template/launcher_config/main.conf
@@ -5,7 +5,7 @@ app_id = com.canonical.certification:CertLab_testflinger_testing
 [ui]
 type = silent
 
-[daemon]
+[agent]
 normal_user = ubuntu
 
 [transport:local_file]


### PR DESCRIPTION
Below message is popped up:
Config: daemon section name is deprecated. Use agent instead. Connecting to 10.102.180.115:18871. Timeout: 600s