### PR TITLE
change: Remove --spec from pipx because it's not supported

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/15_install_checkbox_on_agent
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/15_install_checkbox_on_agent
@@ -7,9 +7,13 @@ sudo apt update
 sudo DEBIAN_FRONTEND=noninteractive apt install -yqq checkbox-ng python3-venv sshpass jq pipx
 
 echo "Installing checkbox in agent container"
-CHECKBOX_VERSION=$(_run $CHECKBOX_CLI_CMD --version)
 git clone --depth=1 https://github.com/canonical/hwcert-jenkins-tools.git > /dev/null
 git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
+
+# checkout commit to match the required version
+CHECKBOX_VERSION=$(_run $CHECKBOX_CLI_CMD --version)
 hwcert-jenkins-tools/version-published/checkout_to_version.py ~/checkbox "$CHECKBOX_VERSION"
-pipx install --spec checkbox/checkbox-ng checkbox-ng
+
+CHECKBOX_SOURCE_INSTALL_GROUP=${CHECKBOX_SOURCE_INSTALL_GROUP:-$(lsb_release -cs)_prod}
+pipx install checkbox/checkbox-ng["$CHECKBOX_SOURCE_INSTALL_GROUP"]
 sudo rm -rf checkbox


### PR DESCRIPTION
Update the pipx command when installing checkbox, because --spec flag no longer supported.

The same change is already in cert scriptlets:
https://github.com/canonical/certification-lab-ci-tools/blob/afadf13478120ee1bcc459b94f9352061e5d4051/scriptlets/install_checkbox_agent_source#L47C1-L48C66

After fix:
```

+ echo 'Installing checkbox in agent container'
Installing checkbox in agent container
++ _run checkbox-cli --version
++ ssh -t -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@10.102.180.146 checkbox-cli --version
+ CHECKBOX_VERSION=$'6.0.0.dev37\r'
+ git clone --depth=1 https://github.com/canonical/hwcert-jenkins-tools.git
Cloning into 'hwcert-jenkins-tools'...
+ git clone --filter=tree:0 https://github.com/canonical/checkbox.git
Cloning into 'checkbox'...

Updating files: 100% (2485/2485), done.
+ hwcert-jenkins-tools/version-published/checkout_to_version.py /home/ubuntu/checkbox $'6.0.0.dev37\r'
Checkout to 37 commits after the preceding tag v5.0.0
HEAD is now at c8293fa1 Add vscode env for better dev experience working with checkbox using VSCode + gitignore venv folder (Infra)
++ lsb_release -cs
+ CHECKBOX_SOURCE_INSTALL_GROUP=jammy_prod
+ pipx install 'checkbox/checkbox-ng[jammy_prod]'
creating virtual environment...
creating shared libraries...
upgrading shared libraries...
determining package name from '/home/ubuntu/checkbox/checkbox-ng[jammy_prod]'...
2025-08-01 02:21:11,629 dell16-dc16250-0d23-c34236 ERROR: DEVICE CONNECTOR: Error connecting to serial logging server
creating virtual environment...
installing checkbox-ng from spec '/home/ubuntu/checkbox/checkbox-ng[jammy_prod]'...
⚠️  Note: checkbox-cli was already on your PATH at /usr/bin/checkbox-cli
⚠️  Note: checkbox-provider-tools was already on your PATH at
    /usr/bin/checkbox-provider-tools
  installed package checkbox-ng 5.0.1.dev37+gc8293fa1, installed using Python 3.10.12
  These apps are now globally available
    - checkbox-cli
    - checkbox-provider-tools
⚠️  Note: '/home/ubuntu/.local/bin' is not on your PATH environment variable.
    These apps will not be globally accessible until your PATH is updated. Run
    `pipx ensurepath` to automatically add it, or manually modify your PATH in
    your shell's config file (i.e. ~/.bashrc).
done! ✨ 🌟 ✨
+ sudo rm -rf checkbox

```


Closes: https://warthogs.atlassian.net/browse/OEX86-772

