### PR TITLE
change: rename dcd.info to machine-info.json and add c3 machines/ data

### DIFF
--- a/Tools/PC/testflinger_yaml_generator/template/shell_scripts/00_initial
+++ b/Tools/PC/testflinger_yaml_generator/template/shell_scripts/00_initial
@@ -36,7 +36,8 @@ wait_for_ssh() {{
     done
 }}
 
-DCD=$(_run ubuntu-report show | grep \"DCD\": | awk '{print $2}')
+DCD=$(_run ubuntu-report show | grep \"DCD\": | awk '{print $2}' | tr -d '"\r')
+MACHINE_INFO=$(_run curl https://api.tel.certification.canonical.com/api/v2/machines/"$CID"/)
 
 echo
 echo "====== TARGET DEVICE CONNECTION INFO ======"
@@ -48,7 +49,9 @@ echo "==========================================="
 echo
 
 mkdir -p artifacts
-echo "$DCD" > artifacts/dcd.info
+MACHINE_INFO_FILE="artifacts/machine-info.json"
+echo "$MACHINE_INFO" > "$MACHINE_INFO_FILE"
+jq --arg new_string "$DCD" '.DCD = $new_string' "$MACHINE_INFO_FILE" > tmp.json && mv tmp.json $MACHINE_INFO_FILE
 echo "Files in artifacts:"
 ls artifacts
 


### PR DESCRIPTION
Description:
This change will rename dcd.info file to machine-info.json. It will make DUT to get data from C3 machines/$CID endpoint and add it to machine-info.json. The new file can be used to get project, platform-tag, canonical_label and others.

Tests:
1. generate new job.yaml
2. submitted job will create the file
https://paste.ubuntu.com/p/35WmwHvGMY/
3. get TF artifact and confirm machine-info.json has the dcd and other c3 data
```
$ jq '.' machine-info.json 
{
  "id": 36514,
  "account": {
    "id": 2,
    "name": "Hewlett Packard (HP)",
    "website": "http://www.hp.com",
    "phone": "+1 886-2-8722-8394",
    "fax": "",
    "billing_street": "21222 Tomball Parkway",
    "billing_city": "Houston",
    "billing_state": "TX",
    "billing_postal_code": "77070",
    "billing_country": "US",
    "account_type": "Manufacturer - PC/Server",
    "secure_id": "00120000004FFoz",
    "record_type_id": "01220000000DcN8",
    "display_groups": "",
    "user_groups": [
      55,
      1
    ]
  },
  "arch_name": "x86_64",
  "canonical_contact": {
    "id": 503,
    "name": "jasonyen",
    "display_name": "Jason Yen",
    "self_link": "https://api.launchpad.net/devel/~jasonyen",
    "launchpad_status": "Active"
  },
  "canonical_id": "202503-36514",
  "canonical_label": "MACHU14W-PV-SKU24",
  "comment": "",
  "configuration": 7450,
  "cpu_codename": "Intel® Core Ultra 2 - Arrow Lake",
  "cpu_id": "52 06 0C 00 FF FB EB BF",
  "customized_queues": [],
  "date_received": "2025-03-17",
  "device_id": "hp-zbook-8-g1i-14-inch-mobile-workstation-pc-1234567aba-c36514",
  "hardware_build": "PV",
  "holder": {
    "id": 4114,
    "name": "artur-at-work",
    "display_name": "Artur Pak",
    "self_link": "https://api.launchpad.net/devel/~artur-at-work",
    "launchpad_status": "Active"
  },
  "in_oil": false,
  "is_confidential": true,
  "launchpad_tag": "numbat-moa",
  "location_name": "Taipei Eongher - Lab-10",
  "return_destination": "",
  "maas_node_id": null,
  "mac_address": "28:c5:c8:99:64:d4",
  "parent": null,
  "platform": {
    "id": 15280,
    "name": "ZBook 8 G1i 14 inch Mobile Workstation PC",
    "codename": "MachuW14"
  },
  "provision_type": "oem_autoinstall",
  "projects": [
    {
      "id": 204,
      "name": "Stella",
      "contact_name": "billchyu"
    }
  ],
  "resource_uri": "/api/v2/machines/202503-36514/",
  "role": "DUT",
  "secure_id": "G3z8F9EHfgWZpDoC2Q56dv",
  "serial_number": "",
  "status": "With Canonical",
  "testflinger_approved": true,
  "website": "",
  "test_settings": null,
  "DCD": "canonical-oem-stella-noble-oem-24.04c-20250723-43"
}
```
